### PR TITLE
fix: profile detection and extension inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ __Inheritance Priority__: This extension respects the settings you declare in yo
 ---
 
 ## 💡 How Does This Extension Work?
-This extension allows you to inherit from multiple other profiles. In order to apply settings, you must include them in either the global, workspace, workspace file, or profile settings file. This extension places inherited settings directly into the profile `settings.json`.
+This extension allows you to inherit from multiple other profiles. In order to apply settings, you must include them in either the global, workspace, workspace file, or profile settings file. This extension places inherited settings directly into the profile `settings.json`, and it also merges inherited extensions into the profile `extensions.json`.
 
 ### 1: Collecting the Inherited Settings
 First, the extension will read the settings for each of the profiles you have elected to inherit from. It will then flatten each of the settings keys into a single string key and store it alongside it's value. As the extension iterates through the different `settings.json` files from each inherited profile, it will override any existing settings with new ones. This is done according to the order that the profiles appear in in the `inheritProfile.parents` setting.
@@ -107,11 +107,12 @@ The final inherited settings are then inserted into the current profile between 
         "hello": "something"
     },
     // --- INHERITED SETTINGS MARKER START --- //
-    "two": "some other value"
+    "two": "some other value",
     // --- INHERITED SETTINGS MARKER END --- //
+    "inheritProfile._insertionBoundary": false
 }
 ```
-> __Note__: It is important that the start and end markers are left alone. These are used by the extension to identify the settings that have been inherited to the current profile.
+> __Note__: It is important that the start and end markers and the `inheritProfile._insertionBoundary` setting are left alone. The extension uses them to identify the inherited settings block, and the dummy setting keeps newly added settings outside the protected section.
 
 ---
 
@@ -122,7 +123,7 @@ The final inherited settings are then inserted into the current profile between 
 - [x] Implement formatting for inherited settings (indentation).
 - [x] Add a warning comment inside the inherited settings.
 - [ ] Tidy up [`profiles.ts`](src/profiles.ts).
-- [ ] Implement extension inheritance. This should be disabled by default, but
-  should be possible to enable through configuration.
+- [x] Implement extension inheritance.
+- [ ] Add a configuration option to disable extension inheritance.
 - [ ] Implement unit testing.
 - [ ] Implement proper CI with auto-release.

--- a/package.json
+++ b/package.json
@@ -83,6 +83,11 @@
           "type": "boolean",
           "default": false,
           "description": "Shows a message when settings are inherited or removed."
+        },
+        "inheritProfile._insertionBoundary": {
+          "type": "boolean",
+          "default": false,
+          "description": "Internal setting used to keep new settings outside the inherited block."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   ],
   "main": "./out/extension.js",
   "extensionKind": [
-    "workspace"
+    "ui"
   ],
   "contributes": {
     "commands": [

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "onStartupFinished"
   ],
   "main": "./out/extension.js",
+  "extensionKind": [
+    "workspace"
+  ],
   "contributes": {
     "commands": [
       {

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -199,6 +199,34 @@ async function getProfileMap(
 }
 
 /**
+ * Gets the current profile name, directory, and full profile map.
+ * @param context Extension context.
+ * @returns Returns details about the current profile.
+ */
+async function getCurrentProfileDetails(
+  context: vscode.ExtensionContext,
+): Promise<{
+  currentProfileName: string;
+  currentProfileDirectory: string;
+  profiles: Record<string, string>;
+}> {
+  const currentProfileName = await getCurrentProfileName(context);
+  const profiles = await getProfileMap(context);
+  const currentProfileDirectory = profiles[currentProfileName];
+  if (!currentProfileDirectory) {
+    throw new Error(
+      `Unable to find current profile directory for \`${currentProfileName}\` profile.`,
+    );
+  }
+
+  return {
+    currentProfileName,
+    currentProfileDirectory,
+    profiles,
+  };
+}
+
+/**
  * Recursively flattens settings into a single record that maps the setting key
  * to its value.
  * @param settings Settings to flatten.
@@ -269,7 +297,9 @@ async function getProfileSettings(
     const settingsPath = path.join(profilePath, "settings.json");
     // TODO: We could also collect extensions here
 
-    const profileSettings = flattenSettings(await readJSON(settingsPath));
+    const profileSettings = stripManagedProfileSettings(
+      flattenSettings(await readJSON(settingsPath)),
+    );
     console.debug(
       `Found ${Object.keys(profileSettings).length} settings from \`${settingsPath}\`.`,
     );
@@ -278,7 +308,7 @@ async function getProfileSettings(
       `Merged ${settingsPath} into collected settings. Current total settings ${Object.keys(settings).length}.`,
     );
   }
-  return flattenSettings(settings);
+  return stripManagedProfileSettings(settings);
 }
 
 /**
@@ -369,11 +399,37 @@ const INHERITED_SETTINGS_START_MARKER =
   "// --- INHERITED SETTINGS MARKER START --- //";
 const INHERITED_SETTINGS_END_MARKER =
   "// --- INHERITED SETTINGS MARKER END --- //";
+const INHERITED_SETTINGS_INSERTION_BOUNDARY_KEY =
+  "inheritProfile._insertionBoundary";
+const INHERITED_SETTINGS_INSERTION_BOUNDARY_VALUE = false;
 
 const WARNING_COMMENT =
   "// WARNING: Do not remove the inherited settings start and end markers.";
 const WARNING_EXPLAIN =
   "//          The markers are used to identify inserted inherited settings.";
+
+function stripManagedProfileSettings<T>(
+  settings: Record<string, T>,
+): Record<string, T> {
+  const strippedSettings = { ...settings };
+  delete strippedSettings[INHERITED_SETTINGS_INSERTION_BOUNDARY_KEY];
+  return strippedSettings;
+}
+
+function removeInsertionBoundarySetting(after: string): string {
+  const boundaryIndex = after.indexOf(
+    `"${INHERITED_SETTINGS_INSERTION_BOUNDARY_KEY}"`,
+  );
+  if (boundaryIndex === -1) {
+    return after;
+  }
+
+  const lineStart = after.lastIndexOf("\n", boundaryIndex);
+  const start = lineStart === -1 ? 0 : lineStart + 1;
+  const lineEnd = after.indexOf("\n", boundaryIndex);
+  const end = lineEnd === -1 ? after.length : lineEnd + 1;
+  return after.slice(0, start) + after.slice(end);
+}
 
 /**
  * Removes the inherited settings block (including the markers) from a settings
@@ -413,7 +469,9 @@ async function removeInheritedSettingsFromFile(
 
   // Clean response:
   const before = raw.slice(0, startIndex);
-  const after = raw.slice(endIndex + INHERITED_SETTINGS_END_MARKER.length);
+  const after = removeInsertionBoundarySetting(
+    raw.slice(endIndex + INHERITED_SETTINGS_END_MARKER.length),
+  );
   let cleaned = before.trimEnd() + after.trimEnd();
 
   // Ensure JSONC ends properly:
@@ -570,9 +628,14 @@ async function writeInheritedSettings(
  * Reads and returns a raw `settings.json` file.
  */
 async function readRawSettingsFile(settingsPath: string): Promise<string> {
-  // Read the raw file:
-  // NOTE: This will throw an exception if the file cannot be read.
-  return await fs.readFile(settingsPath, "utf8");
+  try {
+    return await fs.readFile(settingsPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return "{\n}\n";
+    }
+    throw error;
+  }
 }
 
 /**
@@ -643,6 +706,8 @@ function buildInheritedSettingsBlock(
   const entries = Object.entries(flattened)
     .map(([key, value]) => `${tab}"${key}": ${JSON.stringify(value)}`)
     .join(",\n");
+  const insertionBoundaryEntry =
+    `${tab}"${INHERITED_SETTINGS_INSERTION_BOUNDARY_KEY}": ${JSON.stringify(INHERITED_SETTINGS_INSERTION_BOUNDARY_VALUE)}`;
 
   return (
     tab +
@@ -655,9 +720,11 @@ function buildInheritedSettingsBlock(
     WARNING_EXPLAIN +
     "\n" +
     entries +
-    (entries ? "\n" : "") +
+    (entries ? ",\n" : "") +
     tab +
     INHERITED_SETTINGS_END_MARKER +
+    "\n" +
+    insertionBoundaryEntry +
     "\n"
   );
 }
@@ -808,15 +875,8 @@ function getLastMeaningfulCharacterIndex(text: string): number {
 async function applyInheritedSettings(
   context: vscode.ExtensionContext,
 ): Promise<void> {
-  // Get the path to the current profile settings:
-  const currentProfileName = await getCurrentProfileName(context);
-  const profiles = await getProfileMap(context);
-  const currentProfileDirectory = profiles[currentProfileName];
-  if (!currentProfileDirectory) {
-    console.error(
-      `Unable to find current profile directory for \`${currentProfileName}\` profile.`,
-    );
-  }
+  const { currentProfileName, currentProfileDirectory, profiles } =
+    await getCurrentProfileDetails(context);
   const currentProfilePath = path.join(
     currentProfileDirectory,
     "settings.json",
@@ -831,15 +891,12 @@ async function applyInheritedSettings(
   console.info(
     `Found ${totalInheritedSettings} inherited settings for \`${currentProfileName}\` profile.`,
   );
-  if (totalInheritedSettings === 0) {
-    return;
+  if (totalInheritedSettings > 0) {
+    console.info(
+      `Merging ${totalInheritedSettings} settings into \`${currentProfilePath}\`.`,
+    );
+    await writeInheritedSettings(currentProfilePath, inheritedSettings);
   }
-
-  // Add the inherited settings to the end of the profile:
-  console.info(
-    `Merging ${totalInheritedSettings} settings into \`${currentProfilePath}\`.`,
-  );
-  await writeInheritedSettings(currentProfilePath, inheritedSettings);
 
   const currentExtensionsPath = path.join(
     currentProfileDirectory,
@@ -854,14 +911,16 @@ async function applyInheritedSettings(
     currentExtensions,
     profiles,
   );
-  console.info(
-    `Writing ${finalExtensions.length} extensions to \`${currentExtensionsPath}\`.`,
-  );
-  await fs.writeFile(
-    currentExtensionsPath,
-    JSON.stringify(finalExtensions, null, 4) + "\n",
-    "utf8",
-  );
+  if (JSON.stringify(finalExtensions) !== JSON.stringify(currentExtensions)) {
+    console.info(
+      `Writing ${finalExtensions.length} extensions to \`${currentExtensionsPath}\`.`,
+    );
+    await fs.writeFile(
+      currentExtensionsPath,
+      JSON.stringify(finalExtensions, null, 4) + "\n",
+      "utf8",
+    );
+  }
 }
 
 /**
@@ -956,14 +1015,8 @@ export async function updateCurrentProfileInheritance(
 export async function removeCurrentProfileInheritedSettings(
   context: vscode.ExtensionContext,
 ): Promise<void> {
-  const currentProfileName = await getCurrentProfileName(context);
-  const profiles = await getProfileMap(context);
-  const currentProfileDirectory = profiles[currentProfileName];
-  if (!currentProfileDirectory) {
-    console.error(
-      `Unable to find current profile directory for \`${currentProfileName}\` profile.`,
-    );
-  }
+  const { currentProfileName, currentProfileDirectory } =
+    await getCurrentProfileDetails(context);
   const currentProfilePath = path.join(
     currentProfileDirectory,
     "settings.json",
@@ -976,7 +1029,10 @@ export async function removeCurrentProfileInheritedSettings(
       currentProfileDirectory,
       "extensions.json",
     );
-    const currentExtensions = (await readJSON(currentExtensionsPath)) || [];
+    const parsedCurrentExtensions = await readJSON(currentExtensionsPath);
+    const currentExtensions = Array.isArray(parsedCurrentExtensions)
+      ? parsedCurrentExtensions
+      : [];
     const filteredExtensions = currentExtensions.filter((ext: any) => {
       return !ext?.metadata?.inheritedFromProfile;
     });
@@ -1001,7 +1057,7 @@ export async function removeCurrentProfileInheritedSettings(
   const config = vscode.workspace.getConfiguration("inheritProfile");
   if (config.get<boolean>("showMessages", true)) {
     vscode.window.showInformationMessage(
-      "Inherited settings remove from current profile!",
+      "Inherited settings removed from current profile!",
     );
   }
 }

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -751,8 +751,8 @@ async function applyInheritedSettings(context: vscode.ExtensionContext): Promise
     });
     const extensionMap: Record<string, any> = {};
     for (const ext of filteredExtensions) {
-        if (ext.id) {
-            extensionMap[ext.id] = ext;
+        if (ext?.identifier?.id) {
+            extensionMap[ext.identifier.id] = ext;
         }
     }
 
@@ -770,19 +770,20 @@ async function applyInheritedSettings(context: vscode.ExtensionContext): Promise
         }
         const extensionsPath = path.join(profileDirectory, "extensions.json");
         const profileExtensions = await readJSON(extensionsPath) || [];
-        console.info(`Found ${profileExtensions.length} extensions in \`${extensionsPath}\`.`);
+        console.info(`Found ${profileExtensions.length} extensions in \`${profileName}\`.`);
 
         for (const ext of profileExtensions) {
             // Add extension if it does not already exist:
-            if (ext.id && !(ext.id in extensionMap)) {
+            const id = ext?.identifier?.id;
+            if (id && !(id in extensionMap)) {
                 // Mark the extension as inherited:
                 if (!ext.metadata) {
                     ext.metadata = {};
                 }
                 ext.metadata.inheritedFromProfile = profileName;
 
-                extensionMap[ext.id] = ext;
-                console.info(`Inheriting extension \`${ext.id}\` from profile \`${profileName}\`.`);
+                extensionMap[id] = ext;
+                console.info(`Inheriting extension \`${id}\` from profile \`${profileName}\`.`);
             }
         }
     }

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -733,6 +733,56 @@ async function applyInheritedSettings(context: vscode.ExtensionContext): Promise
     // Add the inherited settings to the end of the profile:
     console.info(`Merging ${totalInheritedSettings} settings into \`${currentProfilePath}\`.`);
     await writeInheritedSettings(currentProfilePath, inheritedSettings);
+
+    const currentExtensionsPath = path.join(currentProfileDirectory, "extensions.json");
+    const currentExtensions = await readJSON(currentExtensionsPath) || [];
+
+    // Remove inherited extensions from the current profile, and convert to a map of id -> extension
+    // Inherited extensions have the field `inheritedFromProfile` in their `metadata` object.
+    const filteredExtensions = currentExtensions.filter((ext: any) => {
+        return !ext?.metadata?.inheritedFromProfile;
+    });
+    const extensionMap: Record<string, any> = {};
+    for (const ext of filteredExtensions) {
+        if (ext.id) {
+            extensionMap[ext.id] = ext;
+        }
+    }
+
+    // Get the list of parent profiles:
+    const config = vscode.workspace.getConfiguration("inheritProfile");
+    const parentProfiles = config.get<string[]>("parents", []);
+    console.info(`Collecting extensions from ${parentProfiles.length} parent profiles.`);
+
+    // Collect extensions from each of the parent profiles:
+    for (const profileName of parentProfiles) {
+        const profileDirectory = profiles[profileName];
+        if (!profileDirectory) {
+            console.warn(`Failed to collect extensions for profile ${profileName}: Profile does not exist.`);
+            continue;
+        }
+        const extensionsPath = path.join(profileDirectory, "extensions.json");
+        const profileExtensions = await readJSON(extensionsPath) || [];
+        console.info(`Found ${profileExtensions.length} extensions in \`${extensionsPath}\`.`);
+
+        for (const ext of profileExtensions) {
+            // Add extension if it does not already exist:
+            if (ext.id && !(ext.id in extensionMap)) {
+                // Mark the extension as inherited:
+                if (!ext.metadata) {
+                    ext.metadata = {};
+                }
+                ext.metadata.inheritedFromProfile = profileName;
+
+                extensionMap[ext.id] = ext;
+                console.info(`Inheriting extension \`${ext.id}\` from profile \`${profileName}\`.`);
+            }
+        }
+    }
+
+    const finalExtensions = Object.values(extensionMap);
+    console.info(`Writing ${finalExtensions.length} extensions to \`${currentExtensionsPath}\`.`);
+    await fs.writeFile(currentExtensionsPath, JSON.stringify(finalExtensions, null, 4) + "\n", "utf8");
 }
 
 /**

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -132,9 +132,13 @@ async function getCurrentProfileName(context: vscode.ExtensionContext): Promise<
     
     const workspaceUri: vscode.Uri | undefined = vscode.workspace.workspaceFile || vscode.workspace.workspaceFolders?.at(0)?.uri;
     if (workspaceUri) {
-        const profileId = storage.profileAssociations.workspaces[workspaceUri.toString()];
-        const profile = findByKeyValuePair(storage.userDataProfiles, "location", profileId);
-        return profile?.name || "Default";
+        const workspaceKey = workspaceUri.toString();
+        const workspaceAssociations = storage.profileAssociations?.workspaces;
+        if (workspaceAssociations && Object.prototype.hasOwnProperty.call(workspaceAssociations, workspaceKey)) {
+            const profileId = workspaceAssociations[workspaceKey];
+            const profile = findByKeyValuePair(storage.userDataProfiles, "location", profileId);
+            return profile?.name || "Default";
+        }
     }
     return "Default";
 }

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -319,7 +319,14 @@ async function removeInheritedSettingsFromFile(settingsPath: string): Promise<vo
     console.info(`Removing inherited settings from \`${settingsPath}\`.`);
 
     // Find the start and end markers:
-    let raw = await readRawSettingsFile(settingsPath);
+    let raw = "";
+    try {
+        raw = await readRawSettingsFile(settingsPath);
+    } catch (error) {
+        console.error(`Failed to read settings file at \`${settingsPath}\`:`, error);
+        return;
+    }
+    
     const startIndex = raw.indexOf(INHERITED_SETTINGS_START_MARKER);
     const endIndex = raw.indexOf(INHERITED_SETTINGS_END_MARKER);
 

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -68,9 +68,9 @@ async function getCustomProfiles(context: vscode.ExtensionContext): Promise<any[
  * @returns Returns the record with the given ID.
  */
 function findByKeyValuePair(
-  input: unknown,
-  key: string,
-  value: unknown
+    input: unknown,
+    key: string,
+    value: unknown
 ): any | undefined {
     const seen = new Set<object>();
 
@@ -84,22 +84,22 @@ function findByKeyValuePair(
         seen.add(node as object);
 
         if (!Array.isArray(node)) {
-        if (Object.prototype.hasOwnProperty.call(node, key) && (node as any)[key] === value) {
-            return node;
-        }
-        for (const v of Object.values(node as Record<string, unknown>)) {
-            const found = dfs(v);
-            if (found) {
-                return found;
+            if (Object.prototype.hasOwnProperty.call(node, key) && (node as any)[key] === value) {
+                return node;
             }
-        }
+            for (const v of Object.values(node as Record<string, unknown>)) {
+                const found = dfs(v);
+                if (found) {
+                    return found;
+                }
+            }
         } else {
-        for (const item of node as unknown[]) {
-            const found = dfs(item);
-            if (found) {
-                return found;
+            for (const item of node as unknown[]) {
+                const found = dfs(item);
+                if (found) {
+                    return found;
+                }
             }
-        }
         }
 
         return undefined;
@@ -128,6 +128,13 @@ async function getCurrentProfileName(context: vscode.ExtensionContext): Promise<
                 }
             }
         }
+    }
+    
+    const workspaceUri: vscode.Uri | undefined = vscode.workspace.workspaceFile || vscode.workspace.workspaceFolders?.at(0)?.uri;
+    if (workspaceUri) {
+        const profileId = storage.profileAssociations.workspaces[workspaceUri.toString()];
+        const profile = findByKeyValuePair(storage.userDataProfiles, "location", profileId);
+        return profile?.name || "Default";
     }
     return "Default";
 }
@@ -253,7 +260,7 @@ function subtractSettings(
     const result: Record<string, string> = {};
     for (const [key, value] of Object.entries(base)) {
         if (!(key in toRemove)) {
-        result[key] = value;
+            result[key] = value;
         }
     }
     return result;
@@ -350,92 +357,92 @@ async function removeInheritedSettingsFromFile(settingsPath: string): Promise<vo
  * @returns A new string with the trailing comma removed, or the original string if no trailing comma was found.
  */
 function removeTrailingComma(text: string): string {
-  let lastMeaningfulIndex = -1;
-  let secondToLastMeaningfulIndex = -1;
+    let lastMeaningfulIndex = -1;
+    let secondToLastMeaningfulIndex = -1;
 
-  let inMultiLineComment = false;
-  let inString = false;
-  let stringChar = ''; // Can be ' or "
+    let inMultiLineComment = false;
+    let inString = false;
+    let stringChar = ''; // Can be ' or "
 
-  // This loop is similar to getLastMeaningfulCharacterIndex, but tracks the last TWO meaningful characters.
-  for (let i = 0; i < text.length; i++) {
-    const char = text[i];
-    const prevChar = text[i - 1];
-    const nextChar = text[i + 1];
+    // This loop is similar to getLastMeaningfulCharacterIndex, but tracks the last TWO meaningful characters.
+    for (let i = 0; i < text.length; i++) {
+        const char = text[i];
+        const prevChar = text[i - 1];
+        const nextChar = text[i + 1];
 
-    // State 1: Inside a multi-line comment
-    if (inMultiLineComment) {
-      if (char === '*' && nextChar === '/') {
-        inMultiLineComment = false;
-        i++; // Consume the '/'
-      }
-      continue;
+        // State 1: Inside a multi-line comment
+        if (inMultiLineComment) {
+            if (char === '*' && nextChar === '/') {
+                inMultiLineComment = false;
+                i++; // Consume the '/'
+            }
+            continue;
+        }
+
+        // State 2: Inside a string
+        if (inString) {
+            if (char === stringChar && prevChar !== '\\') {
+                inString = false;
+            }
+            secondToLastMeaningfulIndex = lastMeaningfulIndex;
+            lastMeaningfulIndex = i;
+            continue;
+        }
+
+        // State 3: Default state (not in a comment or string)
+        if (char === '/' && nextChar === '/') {
+            const newlineIndex = text.indexOf('\n', i);
+            if (newlineIndex === -1) {
+                break; // End of file is a comment
+            }
+            i = newlineIndex;
+            continue;
+        }
+
+        if (char === '/' && nextChar === '*') {
+            inMultiLineComment = true;
+            i++; // Consume the '*'
+            continue;
+        }
+
+        if (char === '"' || char === "'") {
+            inString = true;
+            stringChar = char;
+            secondToLastMeaningfulIndex = lastMeaningfulIndex;
+            lastMeaningfulIndex = i;
+            continue;
+        }
+
+        if (!/\s/.test(char)) {
+            secondToLastMeaningfulIndex = lastMeaningfulIndex;
+            lastMeaningfulIndex = i;
+        }
     }
 
-    // State 2: Inside a string
-    if (inString) {
-      if (char === stringChar && prevChar !== '\\') {
-        inString = false;
-      }
-      secondToLastMeaningfulIndex = lastMeaningfulIndex;
-      lastMeaningfulIndex = i;
-      continue;
+    // After parsing, check if we found a trailing comma.
+    if (lastMeaningfulIndex === -1) {
+        return text; // No meaningful characters found.
     }
 
-    // State 3: Default state (not in a comment or string)
-    if (char === '/' && nextChar === '/') {
-      const newlineIndex = text.indexOf('\n', i);
-      if (newlineIndex === -1) {
-        break; // End of file is a comment
-      }
-      i = newlineIndex;
-      continue;
+    const lastMeaningfulChar = text[lastMeaningfulIndex];
+
+    // Case 1: The very last meaningful character is a comma.
+    // e.g., { "a": 1, }
+    if (lastMeaningfulChar === ',') {
+        return text.slice(0, lastMeaningfulIndex) + text.slice(lastMeaningfulIndex + 1);
     }
 
-    if (char === '/' && nextChar === '*') {
-      inMultiLineComment = true;
-      i++; // Consume the '*'
-      continue;
+    // Case 2: The last character is a brace/bracket, and the one before it is a comma.
+    // e.g. { "a": 1, }
+    if ((lastMeaningfulChar === '}' || lastMeaningfulChar === ']') && secondToLastMeaningfulIndex !== -1) {
+        const secondToLastMeaningfulChar = text[secondToLastMeaningfulIndex];
+        if (secondToLastMeaningfulChar === ',') {
+            return text.slice(0, secondToLastMeaningfulIndex) + text.slice(secondToLastMeaningfulIndex + 1);
+        }
     }
 
-    if (char === '"' || char === "'") {
-      inString = true;
-      stringChar = char;
-      secondToLastMeaningfulIndex = lastMeaningfulIndex;
-      lastMeaningfulIndex = i;
-      continue;
-    }
-
-    if (!/\s/.test(char)) {
-      secondToLastMeaningfulIndex = lastMeaningfulIndex;
-      lastMeaningfulIndex = i;
-    }
-  }
-
-  // After parsing, check if we found a trailing comma.
-  if (lastMeaningfulIndex === -1) {
-    return text; // No meaningful characters found.
-  }
-
-  const lastMeaningfulChar = text[lastMeaningfulIndex];
-
-  // Case 1: The very last meaningful character is a comma.
-  // e.g., { "a": 1, }
-  if (lastMeaningfulChar === ',') {
-    return text.slice(0, lastMeaningfulIndex) + text.slice(lastMeaningfulIndex + 1);
-  }
-
-  // Case 2: The last character is a brace/bracket, and the one before it is a comma.
-  // e.g. { "a": 1, }
-  if ((lastMeaningfulChar === '}' || lastMeaningfulChar === ']') && secondToLastMeaningfulIndex !== -1) {
-    const secondToLastMeaningfulChar = text[secondToLastMeaningfulIndex];
-    if (secondToLastMeaningfulChar === ',') {
-      return text.slice(0, secondToLastMeaningfulIndex) + text.slice(secondToLastMeaningfulIndex + 1);
-    }
-  }
-
-  // If neither of the above conditions are met, there's no trailing comma to remove.
-  return text;
+    // If neither of the above conditions are met, there's no trailing comma to remove.
+    return text;
 }
 
 /**
@@ -628,74 +635,74 @@ function* iterateLines(text: string): Generator<[string, number]> {
  * @returns The zero-based index of the last meaningful character, or -1 if none is found.
  */
 function getLastMeaningfulCharacterIndex(text: string): number {
-  let lastMeaningfulIndex = -1;
-  let inMultiLineComment = false;
-  let inString = false;
-  let stringChar = ''; // Can be ' or "
+    let lastMeaningfulIndex = -1;
+    let inMultiLineComment = false;
+    let inString = false;
+    let stringChar = ''; // Can be ' or "
 
-  for (let i = 0; i < text.length; i++) {
-    const char = text[i];
-    const prevChar = text[i - 1];
-    const nextChar = text[i + 1];
+    for (let i = 0; i < text.length; i++) {
+        const char = text[i];
+        const prevChar = text[i - 1];
+        const nextChar = text[i + 1];
 
-    // State 1: Inside a multi-line comment
-    if (inMultiLineComment) {
-      if (char === '*' && nextChar === '/') {
-        inMultiLineComment = false;
-        i++; // Consume the '/' as well
-      }
-      continue;
+        // State 1: Inside a multi-line comment
+        if (inMultiLineComment) {
+            if (char === '*' && nextChar === '/') {
+                inMultiLineComment = false;
+                i++; // Consume the '/' as well
+            }
+            continue;
+        }
+
+        // State 2: Inside a string
+        if (inString) {
+            // Check for the closing quote, ensuring it's not escaped
+            if (char === stringChar && prevChar !== '\\') {
+                inString = false;
+            }
+            // All characters inside a string are considered meaningful for this function's purpose.
+            lastMeaningfulIndex = i;
+            continue;
+        }
+
+        // State 3: Default state (not in a comment or string)
+        // Check for the start of a single-line comment
+        if (char === '/' && nextChar === '/') {
+            // Find the next newline character
+            const newlineIndex = text.indexOf('\n', i);
+            if (newlineIndex === -1) {
+                // No more newlines, so the rest of the file is a comment.
+                // We can stop processing.
+                break;
+            }
+            // Jump execution to the newline character. The loop's i++ will move to the next line.
+            i = newlineIndex;
+            continue;
+        }
+
+        // Check for the start of a multi-line comment
+        if (char === '/' && nextChar === '*') {
+            inMultiLineComment = true;
+            i++; // Consume the '*' as well
+            continue;
+        }
+
+        // Check for the start of a string (handles both double and single quotes)
+        if (char === '"' || char === "'") {
+            inString = true;
+            stringChar = char;
+            lastMeaningfulIndex = i;
+            continue;
+        }
+
+        // If we've reached this point, we are in a "normal" code context.
+        // A character is meaningful if it's not whitespace.
+        if (!/\s/.test(char)) {
+            lastMeaningfulIndex = i;
+        }
     }
 
-    // State 2: Inside a string
-    if (inString) {
-      // Check for the closing quote, ensuring it's not escaped
-      if (char === stringChar && prevChar !== '\\') {
-        inString = false;
-      }
-      // All characters inside a string are considered meaningful for this function's purpose.
-      lastMeaningfulIndex = i;
-      continue;
-    }
-
-    // State 3: Default state (not in a comment or string)
-    // Check for the start of a single-line comment
-    if (char === '/' && nextChar === '/') {
-      // Find the next newline character
-      const newlineIndex = text.indexOf('\n', i);
-      if (newlineIndex === -1) {
-        // No more newlines, so the rest of the file is a comment.
-        // We can stop processing.
-        break;
-      }
-      // Jump execution to the newline character. The loop's i++ will move to the next line.
-      i = newlineIndex;
-      continue;
-    }
-
-    // Check for the start of a multi-line comment
-    if (char === '/' && nextChar === '*') {
-      inMultiLineComment = true;
-      i++; // Consume the '*' as well
-      continue;
-    }
-
-    // Check for the start of a string (handles both double and single quotes)
-    if (char === '"' || char === "'") {
-      inString = true;
-      stringChar = char;
-      lastMeaningfulIndex = i;
-      continue;
-    }
-
-    // If we've reached this point, we are in a "normal" code context.
-    // A character is meaningful if it's not whitespace.
-    if (!/\s/.test(char)) {
-      lastMeaningfulIndex = i;
-    }
-  }
-
-  return lastMeaningfulIndex;
+    return lastMeaningfulIndex;
 }
 
 /**
@@ -722,7 +729,7 @@ async function applyInheritedSettings(context: vscode.ExtensionContext): Promise
     if (totalInheritedSettings === 0) {
         return;
     }
-    
+
     // Add the inherited settings to the end of the profile:
     console.info(`Merging ${totalInheritedSettings} settings into \`${currentProfilePath}\`.`);
     await writeInheritedSettings(currentProfilePath, inheritedSettings);

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -9,20 +9,20 @@ import { parse } from "jsonc-parser";
  * @returns Parsed object or {} on error.
  */
 export async function readJSON(filePath: string): Promise<any> {
-    try {
-        const raw = await fs.readFile(filePath, "utf8");
-        return parse(raw); // handles // and /* */ comments
-    } catch (error) {
-        console.error(`Failed to read JSONC at ${filePath}:`, error);
-        return {};
-    }
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    return parse(raw); // handles // and /* */ comments
+  } catch (error) {
+    console.error(`Failed to read JSONC at ${filePath}:`, error);
+    return {};
+  }
 }
 
 /**
  * @returns The user directory.
  */
 function getUserDirectory(context: vscode.ExtensionContext): string {
-    return path.resolve(context.globalStorageUri.fsPath, "../../");
+  return path.resolve(context.globalStorageUri.fsPath, "../../");
 }
 
 /**
@@ -31,33 +31,37 @@ function getUserDirectory(context: vscode.ExtensionContext): string {
  * @returns Returns the path to the global storage JSON file.
  */
 function getGlobalStoragePath(context: vscode.ExtensionContext): string {
-    return path.resolve(context.globalStorageUri.fsPath, "../storage.json");
+  return path.resolve(context.globalStorageUri.fsPath, "../storage.json");
 }
 
 /**
  * Reads the global storage JSON file.
- * 
+ *
  * This contains a lot of useful information about profiles.
  * @param context Extension context.
  * @returns Returns the contents of the global storage JSON file.
  */
-async function readGlobalStorage(context: vscode.ExtensionContext): Promise<any> {
-    const storagePath: string = getGlobalStoragePath(context);
-    return await readJSON(storagePath);
+async function readGlobalStorage(
+  context: vscode.ExtensionContext,
+): Promise<any> {
+  const storagePath: string = getGlobalStoragePath(context);
+  return await readJSON(storagePath);
 }
 
 /**
  * Extracts the custom profiles section from the global storage JSON file.
- * 
+ *
  * This is useful for finding out the names and paths of the user created
  * profiles.
  * @param context Extension context.
  * @returns Returns the contents of the `userDataProfiles` filed from the global
  * storage JSON file.
  */
-async function getCustomProfiles(context: vscode.ExtensionContext): Promise<any[]> {
-    const storage = await readGlobalStorage(context);
-    return storage.userDataProfiles ?? [];
+async function getCustomProfiles(
+  context: vscode.ExtensionContext,
+): Promise<any[]> {
+  const storage = await readGlobalStorage(context);
+  return storage.userDataProfiles ?? [];
 }
 
 /**
@@ -68,44 +72,47 @@ async function getCustomProfiles(context: vscode.ExtensionContext): Promise<any[
  * @returns Returns the record with the given ID.
  */
 function findByKeyValuePair(
-    input: unknown,
-    key: string,
-    value: unknown
+  input: unknown,
+  key: string,
+  value: unknown,
 ): any | undefined {
-    const seen = new Set<object>();
+  const seen = new Set<object>();
 
-    function dfs(node: unknown): any | undefined {
-        if (node === null || typeof node !== "object") {
-            return undefined;
-        }
-        if (seen.has(node as object)) {
-            return undefined;
-        }
-        seen.add(node as object);
+  function dfs(node: unknown): any | undefined {
+    if (node === null || typeof node !== "object") {
+      return undefined;
+    }
+    if (seen.has(node as object)) {
+      return undefined;
+    }
+    seen.add(node as object);
 
-        if (!Array.isArray(node)) {
-            if (Object.prototype.hasOwnProperty.call(node, key) && (node as any)[key] === value) {
-                return node;
-            }
-            for (const v of Object.values(node as Record<string, unknown>)) {
-                const found = dfs(v);
-                if (found) {
-                    return found;
-                }
-            }
-        } else {
-            for (const item of node as unknown[]) {
-                const found = dfs(item);
-                if (found) {
-                    return found;
-                }
-            }
+    if (!Array.isArray(node)) {
+      if (
+        Object.prototype.hasOwnProperty.call(node, key) &&
+        (node as any)[key] === value
+      ) {
+        return node;
+      }
+      for (const v of Object.values(node as Record<string, unknown>)) {
+        const found = dfs(v);
+        if (found) {
+          return found;
         }
-
-        return undefined;
+      }
+    } else {
+      for (const item of node as unknown[]) {
+        const found = dfs(item);
+        if (found) {
+          return found;
+        }
+      }
     }
 
-    return dfs(input);
+    return undefined;
+  }
+
+  return dfs(input);
 }
 
 /**
@@ -113,34 +120,51 @@ function findByKeyValuePair(
  * @param context Extension context.
  * @returns Returns the name of the current profile.
  */
-async function getCurrentProfileName(context: vscode.ExtensionContext): Promise<string> {
-    const storage = await readGlobalStorage(context);
-    const profilesSubMenu = findByKeyValuePair(storage, "id", "submenuitem.Profiles");
-    if (profilesSubMenu) {
-        const submenuItems = profilesSubMenu.submenu.items;
-        for (const submenuItem of submenuItems) {
-            if (submenuItem.checked) {
-                const fullProfileId: string = submenuItem.id;
-                const profileId = fullProfileId.substring(fullProfileId.lastIndexOf(".") + 1);
-                const profileData = findByKeyValuePair(storage, "location", profileId);
-                if (profileData) {
-                    return profileData.name;
-                }
-            }
+async function getCurrentProfileName(
+  context: vscode.ExtensionContext,
+): Promise<string> {
+  const storage = await readGlobalStorage(context);
+  const profilesSubMenu = findByKeyValuePair(
+    storage,
+    "id",
+    "submenuitem.Profiles",
+  );
+  if (profilesSubMenu) {
+    const submenuItems = profilesSubMenu.submenu.items;
+    for (const submenuItem of submenuItems) {
+      if (submenuItem.checked) {
+        const fullProfileId: string = submenuItem.id;
+        const profileId = fullProfileId.substring(
+          fullProfileId.lastIndexOf(".") + 1,
+        );
+        const profileData = findByKeyValuePair(storage, "location", profileId);
+        if (profileData) {
+          return profileData.name;
         }
+      }
     }
-    
-    const workspaceUri: vscode.Uri | undefined = vscode.workspace.workspaceFile || vscode.workspace.workspaceFolders?.at(0)?.uri;
-    if (workspaceUri) {
-        const workspaceKey = workspaceUri.toString();
-        const workspaceAssociations = storage.profileAssociations?.workspaces;
-        if (workspaceAssociations && Object.prototype.hasOwnProperty.call(workspaceAssociations, workspaceKey)) {
-            const profileId = workspaceAssociations[workspaceKey];
-            const profile = findByKeyValuePair(storage.userDataProfiles, "location", profileId);
-            return profile?.name || "Default";
-        }
+  }
+
+  const workspaceUri: vscode.Uri | undefined =
+    vscode.workspace.workspaceFile ||
+    vscode.workspace.workspaceFolders?.at(0)?.uri;
+  if (workspaceUri) {
+    const workspaceKey = workspaceUri.toString();
+    const workspaceAssociations = storage.profileAssociations?.workspaces;
+    if (
+      workspaceAssociations &&
+      Object.prototype.hasOwnProperty.call(workspaceAssociations, workspaceKey)
+    ) {
+      const profileId = workspaceAssociations[workspaceKey];
+      const profile = findByKeyValuePair(
+        storage.userDataProfiles,
+        "location",
+        profileId,
+      );
+      return profile?.name || "Default";
     }
-    return "Default";
+  }
+  return "Default";
 }
 
 /**
@@ -149,23 +173,29 @@ async function getCurrentProfileName(context: vscode.ExtensionContext): Promise<
  * @param context Extension context.
  * @returns A mapping from profile name to the directory for the profile.
  */
-async function getProfileMap(context: vscode.ExtensionContext): Promise<Record<string, string>> {
-    const map: Record<string, string> = {};
-    const userDirectory = getUserDirectory(context);
+async function getProfileMap(
+  context: vscode.ExtensionContext,
+): Promise<Record<string, string>> {
+  const map: Record<string, string> = {};
+  const userDirectory = getUserDirectory(context);
 
-    // Add the default profile:
-    // NOTE: The default profile always exists in the user directory.
-    map["Default"] = userDirectory;
+  // Add the default profile:
+  // NOTE: The default profile always exists in the user directory.
+  map["Default"] = userDirectory;
 
-    // Add the custom profiles:
-    let customProfiles: any[] = await getCustomProfiles(context);
-    for (const profile of customProfiles) {
-        if (profile.name && profile.location) {
-            map[profile.name] = path.join(userDirectory, "profiles", profile.location);
-        }
+  // Add the custom profiles:
+  let customProfiles: any[] = await getCustomProfiles(context);
+  for (const profile of customProfiles) {
+    if (profile.name && profile.location) {
+      map[profile.name] = path.join(
+        userDirectory,
+        "profiles",
+        profile.location,
+      );
     }
+  }
 
-    return map;
+  return map;
 }
 
 /**
@@ -177,19 +207,19 @@ async function getProfileMap(context: vscode.ExtensionContext): Promise<Record<s
  * @returns Returns the flattened result.
  */
 function flattenSettings(
-    settings: Record<string, any>,
-    parentKey = "",
-    result: Record<string, any> = {}
+  settings: Record<string, any>,
+  parentKey = "",
+  result: Record<string, any> = {},
 ): Record<string, any> {
-    for (const [key, value] of Object.entries(settings)) {
-        const newKey = parentKey ? `${parentKey}.${key}` : key;
-        if (value && typeof value === "object" && !Array.isArray(value)) {
-            flattenSettings(value, newKey, result);
-        } else {
-            result[newKey] = value;
-        }
+  for (const [key, value] of Object.entries(settings)) {
+    const newKey = parentKey ? `${parentKey}.${key}` : key;
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      flattenSettings(value, newKey, result);
+    } else {
+      result[newKey] = value;
     }
-    return result;
+  }
+  return result;
 }
 
 /**
@@ -203,16 +233,15 @@ function flattenSettings(
  * result = { "editor.fontSize": "16", "files.autoSave": "off" }
  */
 function mergeFlattenedSettings(
-    target: Record<string, string>,
-    source: Record<string, string>
+  target: Record<string, string>,
+  source: Record<string, string>,
 ): Record<string, string> {
-    return { ...target, ...source };
+  return { ...target, ...source };
 }
-
 
 /**
  * Collects the settings for each of the profiles.
- * 
+ *
  * This function will start with the first profile in the list. This function
  * will override properties that are redefined in profiles that appear towards
  * the end of the list.
@@ -220,25 +249,36 @@ function mergeFlattenedSettings(
  * @param profiles List of profiles to collect settings for.
  * @returns Flattened settings from the provided profiles.
  */
-async function getProfileSettings(context: vscode.ExtensionContext, profiles: string[]): Promise<Record<string, string>> {
-    const profileMap: Record<string, string> = await getProfileMap(context);
-    var settings: Record<string, string> = {};
-    console.debug(`Collecting settings from ${profiles.length} different profiles.`);
-    for (const profileName of profiles) {
-        const profilePath = profileMap[profileName];
-        if (!profilePath) {
-            console.warn(`Failed to collect settings for profile ${profileName}: Profile does not exist.`);
-            continue;
-        }
-        const settingsPath = path.join(profilePath, "settings.json");
-        // TODO: We could also collect extensions here
-
-        const profileSettings = flattenSettings(await readJSON(settingsPath));
-        console.debug(`Found ${Object.keys(profileSettings).length} settings from \`${settingsPath}\`.`);
-        settings = mergeFlattenedSettings(settings, profileSettings);
-        console.debug(`Merged ${settingsPath} into collected settings. Current total settings ${Object.keys(settings).length}.`);
+async function getProfileSettings(
+  context: vscode.ExtensionContext,
+  profiles: string[],
+): Promise<Record<string, string>> {
+  const profileMap: Record<string, string> = await getProfileMap(context);
+  var settings: Record<string, string> = {};
+  console.debug(
+    `Collecting settings from ${profiles.length} different profiles.`,
+  );
+  for (const profileName of profiles) {
+    const profilePath = profileMap[profileName];
+    if (!profilePath) {
+      console.warn(
+        `Failed to collect settings for profile ${profileName}: Profile does not exist.`,
+      );
+      continue;
     }
-    return flattenSettings(settings);
+    const settingsPath = path.join(profilePath, "settings.json");
+    // TODO: We could also collect extensions here
+
+    const profileSettings = flattenSettings(await readJSON(settingsPath));
+    console.debug(
+      `Found ${Object.keys(profileSettings).length} settings from \`${settingsPath}\`.`,
+    );
+    settings = mergeFlattenedSettings(settings, profileSettings);
+    console.debug(
+      `Merged ${settingsPath} into collected settings. Current total settings ${Object.keys(settings).length}.`,
+    );
+  }
+  return flattenSettings(settings);
 }
 
 /**
@@ -246,28 +286,32 @@ async function getProfileSettings(context: vscode.ExtensionContext, profiles: st
  * @param context Extension context.
  * @returns Returns the flattened settings for the current profile.
  */
-async function getCurrentProfileSettings(context: vscode.ExtensionContext): Promise<Record<string, string>> {
-    const currentProfileName = await getCurrentProfileName(context);
-    return flattenSettings(await getProfileSettings(context, [currentProfileName]));
+async function getCurrentProfileSettings(
+  context: vscode.ExtensionContext,
+): Promise<Record<string, string>> {
+  const currentProfileName = await getCurrentProfileName(context);
+  return flattenSettings(
+    await getProfileSettings(context, [currentProfileName]),
+  );
 }
 
 /**
  * Subtracts one set of settings from another.
  * @param base Base settings.
  * @param toRemove Settings to remove from the base.
- * @returns 
+ * @returns
  */
 function subtractSettings(
-    base: Record<string, string>,
-    toRemove: Record<string, string>
+  base: Record<string, string>,
+  toRemove: Record<string, string>,
 ): Record<string, string> {
-    const result: Record<string, string> = {};
-    for (const [key, value] of Object.entries(base)) {
-        if (!(key in toRemove)) {
-            result[key] = value;
-        }
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(base)) {
+    if (!(key in toRemove)) {
+      result[key] = value;
     }
-    return result;
+  }
+  return result;
 }
 
 /**
@@ -276,14 +320,14 @@ function subtractSettings(
  * @returns Returns the `settings`, but sorted alphabetically (A to Z).
  */
 function sortSettings(
-    settings: Record<string, string>
+  settings: Record<string, string>,
 ): Record<string, string> {
-    return Object.keys(settings)
-        .sort((a, b) => a.localeCompare(b))
-        .reduce<Record<string, string>>((acc, key) => {
-            acc[key] = settings[key];
-            return acc;
-        }, {});
+  return Object.keys(settings)
+    .sort((a, b) => a.localeCompare(b))
+    .reduce<Record<string, string>>((acc, key) => {
+      acc[key] = settings[key];
+      return acc;
+    }, {});
 }
 
 /**
@@ -291,70 +335,95 @@ function sortSettings(
  * @param context Extension context.
  * @returns Returns the flattened settings that are missing from the current profile.
  */
-async function getInheritedSettings(context: vscode.ExtensionContext): Promise<Record<string, string>> {
-    const currentProfileSettings = await getCurrentProfileSettings(context);
-    console.info(`Found ${Object.keys(currentProfileSettings).length} settings in current profile.`);
+async function getInheritedSettings(
+  context: vscode.ExtensionContext,
+): Promise<Record<string, string>> {
+  const currentProfileSettings = await getCurrentProfileSettings(context);
+  console.info(
+    `Found ${Object.keys(currentProfileSettings).length} settings in current profile.`,
+  );
 
-    const config = vscode.workspace.getConfiguration("inheritProfile");
-    const parentProfiles = config.get<string[]>("parents", []);
-    const parentProfileSettings = await getProfileSettings(context, parentProfiles);
-    console.info(`Found ${Object.keys(parentProfileSettings).length} settings in parent profiles.`);
+  const config = vscode.workspace.getConfiguration("inheritProfile");
+  const parentProfiles = config.get<string[]>("parents", []);
+  const parentProfileSettings = await getProfileSettings(
+    context,
+    parentProfiles,
+  );
+  console.info(
+    `Found ${Object.keys(parentProfileSettings).length} settings in parent profiles.`,
+  );
 
-    const inheritedSettings = subtractSettings(parentProfileSettings, currentProfileSettings);
-    console.info(`Found ${Object.keys(inheritedSettings).length} inherited in from parent profiles.`);
+  const inheritedSettings = subtractSettings(
+    parentProfileSettings,
+    currentProfileSettings,
+  );
+  console.info(
+    `Found ${Object.keys(inheritedSettings).length} inherited in from parent profiles.`,
+  );
 
-    const sortedInheritedSettings = sortSettings(inheritedSettings);
-    return sortedInheritedSettings;
+  const sortedInheritedSettings = sortSettings(inheritedSettings);
+  return sortedInheritedSettings;
 }
 
-const INHERITED_SETTINGS_START_MARKER = "// --- INHERITED SETTINGS MARKER START --- //";
-const INHERITED_SETTINGS_END_MARKER = "// --- INHERITED SETTINGS MARKER END --- //";
+const INHERITED_SETTINGS_START_MARKER =
+  "// --- INHERITED SETTINGS MARKER START --- //";
+const INHERITED_SETTINGS_END_MARKER =
+  "// --- INHERITED SETTINGS MARKER END --- //";
 
-const WARNING_COMMENT = "// WARNING: Do not remove the inherited settings start and end markers.";
-const WARNING_EXPLAIN = "//          The markers are used to identify inserted inherited settings.";
+const WARNING_COMMENT =
+  "// WARNING: Do not remove the inherited settings start and end markers.";
+const WARNING_EXPLAIN =
+  "//          The markers are used to identify inserted inherited settings.";
 
 /**
  * Removes the inherited settings block (including the markers) from a settings
  * file.
- * 
+ *
  * If no markers are found, the file is left unchanged.
  */
-async function removeInheritedSettingsFromFile(settingsPath: string): Promise<void> {
-    console.info(`Removing inherited settings from \`${settingsPath}\`.`);
+async function removeInheritedSettingsFromFile(
+  settingsPath: string,
+): Promise<void> {
+  console.info(`Removing inherited settings from \`${settingsPath}\`.`);
 
-    // Find the start and end markers:
-    let raw = "";
-    try {
-        raw = await readRawSettingsFile(settingsPath);
-    } catch (error) {
-        console.error(`Failed to read settings file at \`${settingsPath}\`:`, error);
-        return;
+  // Find the start and end markers:
+  let raw = "";
+  try {
+    raw = await readRawSettingsFile(settingsPath);
+  } catch (error) {
+    console.error(
+      `Failed to read settings file at \`${settingsPath}\`:`,
+      error,
+    );
+    return;
+  }
+
+  const startIndex = raw.indexOf(INHERITED_SETTINGS_START_MARKER);
+  const endIndex = raw.indexOf(INHERITED_SETTINGS_END_MARKER);
+
+  // Ensure the markers exist:
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    if (startIndex !== endIndex) {
+      console.warn(
+        "Either the start or end marker is missing in the current profile.",
+      );
     }
-    
-    const startIndex = raw.indexOf(INHERITED_SETTINGS_START_MARKER);
-    const endIndex = raw.indexOf(INHERITED_SETTINGS_END_MARKER);
+    return; // markers not found, leave file alone
+  }
 
-    // Ensure the markers exist:
-    if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
-        if (startIndex !== endIndex) {
-            console.warn("Either the start or end marker is missing in the current profile.");
-        }
-        return; // markers not found, leave file alone
-    }
+  // Clean response:
+  const before = raw.slice(0, startIndex);
+  const after = raw.slice(endIndex + INHERITED_SETTINGS_END_MARKER.length);
+  let cleaned = before.trimEnd() + after.trimEnd();
 
-    // Clean response:
-    const before = raw.slice(0, startIndex);
-    const after = raw.slice(endIndex + INHERITED_SETTINGS_END_MARKER.length);
-    let cleaned = (before.trimEnd() + after.trimEnd());
+  // Ensure JSONC ends properly:
+  cleaned = removeTrailingComma(cleaned);
+  if (!cleaned.endsWith("}")) {
+    cleaned += "\n}";
+  }
 
-    // Ensure JSONC ends properly:
-    cleaned = removeTrailingComma(cleaned);
-    if (!cleaned.endsWith("}")) {
-        cleaned += "\n}";
-    }
-
-    // Write cleaned file:
-    await fs.writeFile(settingsPath, cleaned + "\n", "utf8");
+  // Write cleaned file:
+  await fs.writeFile(settingsPath, cleaned + "\n", "utf8");
 }
 
 /**
@@ -368,154 +437,164 @@ async function removeInheritedSettingsFromFile(settingsPath: string): Promise<vo
  * @returns A new string with the trailing comma removed, or the original string if no trailing comma was found.
  */
 function removeTrailingComma(text: string): string {
-    let lastMeaningfulIndex = -1;
-    let secondToLastMeaningfulIndex = -1;
+  let lastMeaningfulIndex = -1;
+  let secondToLastMeaningfulIndex = -1;
 
-    let inMultiLineComment = false;
-    let inString = false;
-    let stringChar = ''; // Can be ' or "
+  let inMultiLineComment = false;
+  let inString = false;
+  let stringChar = ""; // Can be ' or "
 
-    // This loop is similar to getLastMeaningfulCharacterIndex, but tracks the last TWO meaningful characters.
-    for (let i = 0; i < text.length; i++) {
-        const char = text[i];
-        const prevChar = text[i - 1];
-        const nextChar = text[i + 1];
+  // This loop is similar to getLastMeaningfulCharacterIndex, but tracks the last TWO meaningful characters.
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+    const prevChar = text[i - 1];
+    const nextChar = text[i + 1];
 
-        // State 1: Inside a multi-line comment
-        if (inMultiLineComment) {
-            if (char === '*' && nextChar === '/') {
-                inMultiLineComment = false;
-                i++; // Consume the '/'
-            }
-            continue;
-        }
-
-        // State 2: Inside a string
-        if (inString) {
-            if (char === stringChar && prevChar !== '\\') {
-                inString = false;
-            }
-            secondToLastMeaningfulIndex = lastMeaningfulIndex;
-            lastMeaningfulIndex = i;
-            continue;
-        }
-
-        // State 3: Default state (not in a comment or string)
-        if (char === '/' && nextChar === '/') {
-            const newlineIndex = text.indexOf('\n', i);
-            if (newlineIndex === -1) {
-                break; // End of file is a comment
-            }
-            i = newlineIndex;
-            continue;
-        }
-
-        if (char === '/' && nextChar === '*') {
-            inMultiLineComment = true;
-            i++; // Consume the '*'
-            continue;
-        }
-
-        if (char === '"' || char === "'") {
-            inString = true;
-            stringChar = char;
-            secondToLastMeaningfulIndex = lastMeaningfulIndex;
-            lastMeaningfulIndex = i;
-            continue;
-        }
-
-        if (!/\s/.test(char)) {
-            secondToLastMeaningfulIndex = lastMeaningfulIndex;
-            lastMeaningfulIndex = i;
-        }
+    // State 1: Inside a multi-line comment
+    if (inMultiLineComment) {
+      if (char === "*" && nextChar === "/") {
+        inMultiLineComment = false;
+        i++; // Consume the '/'
+      }
+      continue;
     }
 
-    // After parsing, check if we found a trailing comma.
-    if (lastMeaningfulIndex === -1) {
-        return text; // No meaningful characters found.
+    // State 2: Inside a string
+    if (inString) {
+      if (char === stringChar && prevChar !== "\\") {
+        inString = false;
+      }
+      secondToLastMeaningfulIndex = lastMeaningfulIndex;
+      lastMeaningfulIndex = i;
+      continue;
     }
 
-    const lastMeaningfulChar = text[lastMeaningfulIndex];
-
-    // Case 1: The very last meaningful character is a comma.
-    // e.g., { "a": 1, }
-    if (lastMeaningfulChar === ',') {
-        return text.slice(0, lastMeaningfulIndex) + text.slice(lastMeaningfulIndex + 1);
+    // State 3: Default state (not in a comment or string)
+    if (char === "/" && nextChar === "/") {
+      const newlineIndex = text.indexOf("\n", i);
+      if (newlineIndex === -1) {
+        break; // End of file is a comment
+      }
+      i = newlineIndex;
+      continue;
     }
 
-    // Case 2: The last character is a brace/bracket, and the one before it is a comma.
-    // e.g. { "a": 1, }
-    if ((lastMeaningfulChar === '}' || lastMeaningfulChar === ']') && secondToLastMeaningfulIndex !== -1) {
-        const secondToLastMeaningfulChar = text[secondToLastMeaningfulIndex];
-        if (secondToLastMeaningfulChar === ',') {
-            return text.slice(0, secondToLastMeaningfulIndex) + text.slice(secondToLastMeaningfulIndex + 1);
-        }
+    if (char === "/" && nextChar === "*") {
+      inMultiLineComment = true;
+      i++; // Consume the '*'
+      continue;
     }
 
-    // If neither of the above conditions are met, there's no trailing comma to remove.
-    return text;
+    if (char === '"' || char === "'") {
+      inString = true;
+      stringChar = char;
+      secondToLastMeaningfulIndex = lastMeaningfulIndex;
+      lastMeaningfulIndex = i;
+      continue;
+    }
+
+    if (!/\s/.test(char)) {
+      secondToLastMeaningfulIndex = lastMeaningfulIndex;
+      lastMeaningfulIndex = i;
+    }
+  }
+
+  // After parsing, check if we found a trailing comma.
+  if (lastMeaningfulIndex === -1) {
+    return text; // No meaningful characters found.
+  }
+
+  const lastMeaningfulChar = text[lastMeaningfulIndex];
+
+  // Case 1: The very last meaningful character is a comma.
+  // e.g., { "a": 1, }
+  if (lastMeaningfulChar === ",") {
+    return (
+      text.slice(0, lastMeaningfulIndex) + text.slice(lastMeaningfulIndex + 1)
+    );
+  }
+
+  // Case 2: The last character is a brace/bracket, and the one before it is a comma.
+  // e.g. { "a": 1, }
+  if (
+    (lastMeaningfulChar === "}" || lastMeaningfulChar === "]") &&
+    secondToLastMeaningfulIndex !== -1
+  ) {
+    const secondToLastMeaningfulChar = text[secondToLastMeaningfulIndex];
+    if (secondToLastMeaningfulChar === ",") {
+      return (
+        text.slice(0, secondToLastMeaningfulIndex) +
+        text.slice(secondToLastMeaningfulIndex + 1)
+      );
+    }
+  }
+
+  // If neither of the above conditions are met, there's no trailing comma to remove.
+  return text;
 }
 
 /**
  * Writes a set of inherited settings to a settings path.
- * 
+ *
  * IMPORTANT: This function assumes that there are no inherited settings in the
  * file. Any inherited settings should be removed before calling this function.
  */
 async function writeInheritedSettings(
-    settingsPath: string,
-    flattened: Record<string, any>
+  settingsPath: string,
+  flattened: Record<string, any>,
 ): Promise<void> {
-    // Early exit if there is nothing to add:
-    if (Object.keys(flattened).length === 0) {
-        return;
-    }
+  // Early exit if there is nothing to add:
+  if (Object.keys(flattened).length === 0) {
+    return;
+  }
 
-    // Read the raw file, split it by the closing brace, and get the tab size
-    // for formatting:
-    const raw = await readRawSettingsFile(settingsPath);
-    const [beforeClose, afterClose] = await splitRawSettingsByClosingBrace(raw);
-    const tab = findTabValue(raw);
+  // Read the raw file, split it by the closing brace, and get the tab size
+  // for formatting:
+  const raw = await readRawSettingsFile(settingsPath);
+  const [beforeClose, afterClose] = await splitRawSettingsByClosingBrace(raw);
+  const tab = findTabValue(raw);
 
-    // Build the inherited settings block:
-    const block = buildInheritedSettingsBlock(flattened, tab);
+  // Build the inherited settings block:
+  const block = buildInheritedSettingsBlock(flattened, tab);
 
-    // Insert the inherited settings block between the before and after closing
-    // brace blocks:
-    const beforeClosePlusBlock = insertBeforeClose(beforeClose, block);
-    const finalSettings = beforeClosePlusBlock + afterClose;
+  // Insert the inherited settings block between the before and after closing
+  // brace blocks:
+  const beforeClosePlusBlock = insertBeforeClose(beforeClose, block);
+  const finalSettings = beforeClosePlusBlock + afterClose;
 
-    // Write the final settings to the settings path:
-    await fs.writeFile(settingsPath, finalSettings, "utf8");
+  // Write the final settings to the settings path:
+  await fs.writeFile(settingsPath, finalSettings, "utf8");
 }
 
 /**
  * Reads and returns a raw `settings.json` file.
  */
 async function readRawSettingsFile(settingsPath: string): Promise<string> {
-    // Read the raw file:
-    // NOTE: This will throw an exception if the file cannot be read.
-    return await fs.readFile(settingsPath, "utf8");
+  // Read the raw file:
+  // NOTE: This will throw an exception if the file cannot be read.
+  return await fs.readFile(settingsPath, "utf8");
 }
 
 /**
  * Returns the `raw file in two parts:
  * 1. The content before the closing brace (excluding the closing brace).
  * 2. The content after and including the closing brace.
- * 
+ *
  * @param raw Raw `settings.json` file.
  * @returns Returns `raw` in two parts: before, and after the closing brace.
  */
-function splitRawSettingsByClosingBrace(raw: string): [beforeClose: string, afterClose: string] {
-    // Split the file by the closing brace:
-    let closingIndex = raw.lastIndexOf("}");
-    if (closingIndex === -1) {
-        return ["{\n", "}\n"];
-    }
+function splitRawSettingsByClosingBrace(
+  raw: string,
+): [beforeClose: string, afterClose: string] {
+  // Split the file by the closing brace:
+  let closingIndex = raw.lastIndexOf("}");
+  if (closingIndex === -1) {
+    return ["{\n", "}\n"];
+  }
 
-    const beforeClose = raw.slice(0, closingIndex);
-    const afterClose = raw.slice(closingIndex);
-    return [beforeClose, afterClose];
+  const beforeClose = raw.slice(0, closingIndex);
+  const afterClose = raw.slice(closingIndex);
+  return [beforeClose, afterClose];
 }
 
 /**
@@ -524,117 +603,123 @@ function splitRawSettingsByClosingBrace(raw: string): [beforeClose: string, afte
  * Defaults to 4 spaces if detection fails.
  */
 function findTabValue(raw: string): string {
-    const lines = raw.split(/\r?\n/);
+  const lines = raw.split(/\r?\n/);
 
-    for (const line of lines) {
-        // Skip empty lines and lines without leading whitespace:
-        if (!line.trim()) {
-            continue;
-        }
-
-        const match = line.match(/^( +|\t+)/);
-        if (!match) {
-            continue;
-        }
-
-        const indent = match[1];
-        if (indent[0] === "\t") {
-            return "\t"; // Tabs detected
-        }
-
-        // Spaces: measure run length
-        return " ".repeat(indent.length);
+  for (const line of lines) {
+    // Skip empty lines and lines without leading whitespace:
+    if (!line.trim()) {
+      continue;
     }
 
-    // Fallback tab size:
-    return "    ";
+    const match = line.match(/^( +|\t+)/);
+    if (!match) {
+      continue;
+    }
+
+    const indent = match[1];
+    if (indent[0] === "\t") {
+      return "\t"; // Tabs detected
+    }
+
+    // Spaces: measure run length
+    return " ".repeat(indent.length);
+  }
+
+  // Fallback tab size:
+  return "    ";
 }
 
 /**
  * Builds the inherited settings block with start, warning, entries, and end.
- * 
+ *
  * @param flattened Flattened settings to insert into the settings block.
  * @param tab Tab sequence to use.
  * @returns Returns the raw inherited settings block.
  */
 function buildInheritedSettingsBlock(
-    flattened: Record<string, string>,
-    tab: string,
+  flattened: Record<string, string>,
+  tab: string,
 ): string {
-    const entries = Object.entries(flattened)
-        .map(([key, value]) => `${tab}"${key}": ${JSON.stringify(value)}`)
-        .join(",\n");
+  const entries = Object.entries(flattened)
+    .map(([key, value]) => `${tab}"${key}": ${JSON.stringify(value)}`)
+    .join(",\n");
 
-    return (
-        tab + INHERITED_SETTINGS_START_MARKER + "\n" +
-        tab + WARNING_COMMENT + "\n" +
-        tab + WARNING_EXPLAIN + "\n" +
-        entries + (entries ? "\n" : "") +
-        tab + INHERITED_SETTINGS_END_MARKER + "\n"
-    );
+  return (
+    tab +
+    INHERITED_SETTINGS_START_MARKER +
+    "\n" +
+    tab +
+    WARNING_COMMENT +
+    "\n" +
+    tab +
+    WARNING_EXPLAIN +
+    "\n" +
+    entries +
+    (entries ? "\n" : "") +
+    tab +
+    INHERITED_SETTINGS_END_MARKER +
+    "\n"
+  );
 }
 
 /**
  * Inserts block before closing brace, handling commas and trailing comments.
- * 
+ *
  * Does not remove or modify user comments.
- * 
+ *
  * @returns Returns a string starting with the `beforeClose` block, followed by
  * the `block`. The returned string is formatted JSONC without the final closing
  * bracket.
  */
-function insertBeforeClose(
-    beforeClose: string,
-    block: string,
-): string {
-    // Check last non-comment character:
-    const meaningfulCharIndex = getLastMeaningfulCharacterIndex(beforeClose);
-    if (meaningfulCharIndex === -1) {
-        console.warn("No meaningful text found when attempting to insert `block` after `beforeClose`.");
-        return beforeClose.replace(/\s*$/, "\n") + block;
-    }
-    const meaningfulChar = beforeClose[meaningfulCharIndex];
+function insertBeforeClose(beforeClose: string, block: string): string {
+  // Check last non-comment character:
+  const meaningfulCharIndex = getLastMeaningfulCharacterIndex(beforeClose);
+  if (meaningfulCharIndex === -1) {
+    console.warn(
+      "No meaningful text found when attempting to insert `block` after `beforeClose`.",
+    );
+    return beforeClose.replace(/\s*$/, "\n") + block;
+  }
+  const meaningfulChar = beforeClose[meaningfulCharIndex];
 
-    // Calculate if we should insert a comma after the last meaningful character
-    // index:
-    const needsComma =
-        /\S/.test(beforeClose) &&
-        meaningfulChar !== "{" &&
-        meaningfulChar !== ",";
+  // Calculate if we should insert a comma after the last meaningful character
+  // index:
+  const needsComma =
+    /\S/.test(beforeClose) && meaningfulChar !== "{" && meaningfulChar !== ",";
 
-    // Exit early if we do not need to insert a comma:
-    if (!needsComma) {
-        return beforeClose.replace(/\s*$/, "\n") + block;
-    }
+  // Exit early if we do not need to insert a comma:
+  if (!needsComma) {
+    return beforeClose.replace(/\s*$/, "\n") + block;
+  }
 
-    // Insert a comma after the last meaningful character:
-    const before = beforeClose.slice(0, meaningfulCharIndex + 1);
-    const after = beforeClose.slice(meaningfulCharIndex + 1);
+  // Insert a comma after the last meaningful character:
+  const before = beforeClose.slice(0, meaningfulCharIndex + 1);
+  const after = beforeClose.slice(meaningfulCharIndex + 1);
 
-    return before + "," + after.replace(/\s*$/, "\n") + block;
+  return before + "," + after.replace(/\s*$/, "\n") + block;
 }
 
 /**
  * Iterates through each line in a string, yielding [line, startIndex].
- * 
+ *
  * Handles both LF and CRLF endings.
  */
 function* iterateLines(text: string): Generator<[string, number]> {
-    let start = 0;
+  let start = 0;
 
-    for (let i = 0; i < text.length; i++) {
-        if (text[i] === "\n") {
-            // Handle CRLF (\r\n)
-            const line = text.slice(start, text[i - 1] === "\r" ? i - 1 : i);
-            yield [line, start];
-            start = i + 1;
-        }
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === "\n") {
+      // Handle CRLF (\r\n)
+      const line = text.slice(start, text[i - 1] === "\r" ? i - 1 : i);
+      yield [line, start];
+      start = i + 1;
     }
+  }
 
-    // Final line (if text doesn’t end with a newline)
-    if (start <= text.length) {
-        yield [text.slice(start), start];
-    }
+  // Final line (if text doesn’t end with a newline)
+  if (start <= text.length) {
+    yield [text.slice(start), start];
+  }
 }
 
 /**
@@ -646,238 +731,305 @@ function* iterateLines(text: string): Generator<[string, number]> {
  * @returns The zero-based index of the last meaningful character, or -1 if none is found.
  */
 function getLastMeaningfulCharacterIndex(text: string): number {
-    let lastMeaningfulIndex = -1;
-    let inMultiLineComment = false;
-    let inString = false;
-    let stringChar = ''; // Can be ' or "
+  let lastMeaningfulIndex = -1;
+  let inMultiLineComment = false;
+  let inString = false;
+  let stringChar = ""; // Can be ' or "
 
-    for (let i = 0; i < text.length; i++) {
-        const char = text[i];
-        const prevChar = text[i - 1];
-        const nextChar = text[i + 1];
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+    const prevChar = text[i - 1];
+    const nextChar = text[i + 1];
 
-        // State 1: Inside a multi-line comment
-        if (inMultiLineComment) {
-            if (char === '*' && nextChar === '/') {
-                inMultiLineComment = false;
-                i++; // Consume the '/' as well
-            }
-            continue;
-        }
-
-        // State 2: Inside a string
-        if (inString) {
-            // Check for the closing quote, ensuring it's not escaped
-            if (char === stringChar && prevChar !== '\\') {
-                inString = false;
-            }
-            // All characters inside a string are considered meaningful for this function's purpose.
-            lastMeaningfulIndex = i;
-            continue;
-        }
-
-        // State 3: Default state (not in a comment or string)
-        // Check for the start of a single-line comment
-        if (char === '/' && nextChar === '/') {
-            // Find the next newline character
-            const newlineIndex = text.indexOf('\n', i);
-            if (newlineIndex === -1) {
-                // No more newlines, so the rest of the file is a comment.
-                // We can stop processing.
-                break;
-            }
-            // Jump execution to the newline character. The loop's i++ will move to the next line.
-            i = newlineIndex;
-            continue;
-        }
-
-        // Check for the start of a multi-line comment
-        if (char === '/' && nextChar === '*') {
-            inMultiLineComment = true;
-            i++; // Consume the '*' as well
-            continue;
-        }
-
-        // Check for the start of a string (handles both double and single quotes)
-        if (char === '"' || char === "'") {
-            inString = true;
-            stringChar = char;
-            lastMeaningfulIndex = i;
-            continue;
-        }
-
-        // If we've reached this point, we are in a "normal" code context.
-        // A character is meaningful if it's not whitespace.
-        if (!/\s/.test(char)) {
-            lastMeaningfulIndex = i;
-        }
+    // State 1: Inside a multi-line comment
+    if (inMultiLineComment) {
+      if (char === "*" && nextChar === "/") {
+        inMultiLineComment = false;
+        i++; // Consume the '/' as well
+      }
+      continue;
     }
 
-    return lastMeaningfulIndex;
+    // State 2: Inside a string
+    if (inString) {
+      // Check for the closing quote, ensuring it's not escaped
+      if (char === stringChar && prevChar !== "\\") {
+        inString = false;
+      }
+      // All characters inside a string are considered meaningful for this function's purpose.
+      lastMeaningfulIndex = i;
+      continue;
+    }
+
+    // State 3: Default state (not in a comment or string)
+    // Check for the start of a single-line comment
+    if (char === "/" && nextChar === "/") {
+      // Find the next newline character
+      const newlineIndex = text.indexOf("\n", i);
+      if (newlineIndex === -1) {
+        // No more newlines, so the rest of the file is a comment.
+        // We can stop processing.
+        break;
+      }
+      // Jump execution to the newline character. The loop's i++ will move to the next line.
+      i = newlineIndex;
+      continue;
+    }
+
+    // Check for the start of a multi-line comment
+    if (char === "/" && nextChar === "*") {
+      inMultiLineComment = true;
+      i++; // Consume the '*' as well
+      continue;
+    }
+
+    // Check for the start of a string (handles both double and single quotes)
+    if (char === '"' || char === "'") {
+      inString = true;
+      stringChar = char;
+      lastMeaningfulIndex = i;
+      continue;
+    }
+
+    // If we've reached this point, we are in a "normal" code context.
+    // A character is meaningful if it's not whitespace.
+    if (!/\s/.test(char)) {
+      lastMeaningfulIndex = i;
+    }
+  }
+
+  return lastMeaningfulIndex;
 }
 
 /**
  * Applies the inherited settings to the current profile.
  * @param context Extension context.
  */
-async function applyInheritedSettings(context: vscode.ExtensionContext): Promise<void> {
-    // Get the path to the current profile settings:
-    const currentProfileName = await getCurrentProfileName(context);
-    const profiles = await getProfileMap(context);
-    const currentProfileDirectory = profiles[currentProfileName];
-    if (!currentProfileDirectory) {
-        console.error(`Unable to find current profile directory for \`${currentProfileName}\` profile.`);
-    }
-    const currentProfilePath = path.join(currentProfileDirectory, "settings.json");
+async function applyInheritedSettings(
+  context: vscode.ExtensionContext,
+): Promise<void> {
+  // Get the path to the current profile settings:
+  const currentProfileName = await getCurrentProfileName(context);
+  const profiles = await getProfileMap(context);
+  const currentProfileDirectory = profiles[currentProfileName];
+  if (!currentProfileDirectory) {
+    console.error(
+      `Unable to find current profile directory for \`${currentProfileName}\` profile.`,
+    );
+  }
+  const currentProfilePath = path.join(
+    currentProfileDirectory,
+    "settings.json",
+  );
 
-    // Remove the inherited settings from the current profile:
-    removeInheritedSettingsFromFile(currentProfilePath);
+  // Remove the inherited settings from the current profile:
+  await removeInheritedSettingsFromFile(currentProfilePath);
 
-    // Get the settings that the current profile should inherit:
-    const inheritedSettings = await getInheritedSettings(context);
-    const totalInheritedSettings = Object.keys(inheritedSettings).length;
-    console.info(`Found ${totalInheritedSettings} inherited settings for \`${currentProfileName}\` profile.`);
-    if (totalInheritedSettings === 0) {
-        return;
-    }
+  // Get the settings that the current profile should inherit:
+  const inheritedSettings = await getInheritedSettings(context);
+  const totalInheritedSettings = Object.keys(inheritedSettings).length;
+  console.info(
+    `Found ${totalInheritedSettings} inherited settings for \`${currentProfileName}\` profile.`,
+  );
+  if (totalInheritedSettings === 0) {
+    return;
+  }
 
-    // Add the inherited settings to the end of the profile:
-    console.info(`Merging ${totalInheritedSettings} settings into \`${currentProfilePath}\`.`);
-    await writeInheritedSettings(currentProfilePath, inheritedSettings);
+  // Add the inherited settings to the end of the profile:
+  console.info(
+    `Merging ${totalInheritedSettings} settings into \`${currentProfilePath}\`.`,
+  );
+  await writeInheritedSettings(currentProfilePath, inheritedSettings);
 
-    const currentExtensionsPath = path.join(currentProfileDirectory, "extensions.json");
-    const currentExtensions = await readJSON(currentExtensionsPath) || [];
-    // Collect and write inherited extensions
-    const finalExtensions = await collectInheritedExtensions(currentExtensions, profiles);
-    console.info(`Writing ${finalExtensions.length} extensions to \`${currentExtensionsPath}\`.`);
-    await fs.writeFile(currentExtensionsPath, JSON.stringify(finalExtensions, null, 4) + "\n", "utf8");
+  const currentExtensionsPath = path.join(
+    currentProfileDirectory,
+    "extensions.json",
+  );
+  const parsedCurrentExtensions = await readJSON(currentExtensionsPath);
+  const currentExtensions = Array.isArray(parsedCurrentExtensions)
+    ? parsedCurrentExtensions
+    : [];
+  // Collect and write inherited extensions
+  const finalExtensions = await collectInheritedExtensions(
+    currentExtensions,
+    profiles,
+  );
+  console.info(
+    `Writing ${finalExtensions.length} extensions to \`${currentExtensionsPath}\`.`,
+  );
+  await fs.writeFile(
+    currentExtensionsPath,
+    JSON.stringify(finalExtensions, null, 4) + "\n",
+    "utf8",
+  );
 }
 
 /**
  * Collect extensions from parent profiles, merge with current profile extensions,
  * and mark inherited extensions in their metadata.
  *
- * @param currentProfileDirectory The directory path for the current profile.
  * @param currentExtensions The parsed extensions array from the current profile.
+ * @param profiles A map of profile names to their directory paths.
  * @returns The final extensions array to write back to the current profile.
  */
-async function collectInheritedExtensions(currentExtensions: any[], profiles: Record<string, string>): Promise<any[]> {
-    // Remove inherited extensions from the current profile, and convert to a map of id -> extension
-    // Inherited extensions have the field `inheritedFromProfile` in their `metadata` object.
-    const filteredExtensions = currentExtensions.filter((ext: any) => {
-        return !ext?.metadata?.inheritedFromProfile;
-    });
-    const extensionMap: Record<string, any> = {};
-    for (const ext of filteredExtensions) {
-        if (ext?.identifier?.id) {
-            extensionMap[ext.identifier.id] = ext;
-        }
+async function collectInheritedExtensions(
+  currentExtensions: any[],
+  profiles: Record<string, string>,
+): Promise<any[]> {
+  // Remove inherited extensions from the current profile, and convert to a map of id -> extension
+  // Inherited extensions have the field `inheritedFromProfile` in their `metadata` object.
+  const filteredExtensions = currentExtensions.filter((ext: any) => {
+    return !ext?.metadata?.inheritedFromProfile;
+  });
+  const extensionMap: Record<string, any> = {};
+  for (const ext of filteredExtensions) {
+    if (ext?.identifier?.id) {
+      extensionMap[ext.identifier.id] = ext;
     }
+  }
 
-    // Get the list of parent profiles:
-    const config = vscode.workspace.getConfiguration("inheritProfile");
-    const parentProfiles = config.get<string[]>("parents", []);
-    console.info(`Collecting extensions from ${parentProfiles.length} parent profiles.`);
+  // Get the list of parent profiles:
+  const config = vscode.workspace.getConfiguration("inheritProfile");
+  const parentProfiles = config.get<string[]>("parents", []);
+  console.info(
+    `Collecting extensions from ${parentProfiles.length} parent profiles.`,
+  );
 
-    // Collect extensions from each of the parent profiles:
-    for (const profileName of parentProfiles) {
-        const profileDirectory = profiles[profileName];
-        if (!profileDirectory) {
-            console.warn(`Failed to collect extensions for profile ${profileName}: Profile does not exist.`);
-            continue;
-        }
-        const extensionsPath = path.join(profileDirectory, "extensions.json");
-        const profileExtensions = await readJSON(extensionsPath) || [];
-        console.info(`Found ${profileExtensions.length} extensions in \`${profileName}\`.`);
-
-        for (const ext of profileExtensions) {
-            // Add extension if it does not already exist:
-            const id = ext?.identifier?.id;
-            if (id && !(id in extensionMap)) {
-                // Mark the extension as inherited:
-                if (!ext.metadata) {
-                    ext.metadata = {};
-                }
-                ext.metadata.inheritedFromProfile = profileName;
-
-                extensionMap[id] = ext;
-                console.info(`Inheriting extension \`${id}\` from profile \`${profileName}\`.`);
-            }
-        }
+  // Collect extensions from each of the parent profiles:
+  for (const profileName of parentProfiles) {
+    const profileDirectory = profiles[profileName];
+    if (!profileDirectory) {
+      console.warn(
+        `Failed to collect extensions for profile ${profileName}: Profile does not exist.`,
+      );
+      continue;
     }
+    const extensionsPath = path.join(profileDirectory, "extensions.json");
+    const rawProfileExtensions = await readJSON(extensionsPath);
+    const profileExtensions = Array.isArray(rawProfileExtensions)
+      ? rawProfileExtensions
+      : [];
+    console.info(
+      `Found ${profileExtensions.length} extensions in \`${profileName}\`.`,
+    );
 
-    return Object.values(extensionMap);
+    for (const ext of profileExtensions) {
+      // Add extension if it does not already exist:
+      const id = ext?.identifier?.id;
+      if (id && !(id in extensionMap)) {
+        // Mark the extension as inherited:
+        if (!ext.metadata) {
+          ext.metadata = {};
+        }
+        ext.metadata.inheritedFromProfile = profileName;
+
+        extensionMap[id] = ext;
+        console.info(
+          `Inheriting extension \`${id}\` from profile \`${profileName}\`.`,
+        );
+      }
+    }
+  }
+
+  return Object.values(extensionMap);
 }
 
 /**
  * Updates the inherited settings for the current profile.
  * @param context Extension context.
  */
-export async function updateCurrentProfileInheritance(context: vscode.ExtensionContext): Promise<void> {
-    await applyInheritedSettings(context);
+export async function updateCurrentProfileInheritance(
+  context: vscode.ExtensionContext,
+): Promise<void> {
+  await applyInheritedSettings(context);
 
-    const config = vscode.workspace.getConfiguration("inheritProfile");
-    if (config.get<boolean>("showMessages", true)) {
-        vscode.window.showInformationMessage("Inherited profile settings applied!");
-    }
+  const config = vscode.workspace.getConfiguration("inheritProfile");
+  if (config.get<boolean>("showMessages", true)) {
+    vscode.window.showInformationMessage("Inherited profile settings applied!");
+  }
 }
 
 /**
  * Removes the inherited settings from the current profile.
  * @param context Extension context.
  */
-export async function removeCurrentProfileInheritedSettings(context: vscode.ExtensionContext): Promise<void> {
-    const currentProfileName = await getCurrentProfileName(context);
-    const profiles = await getProfileMap(context);
-    const currentProfileDirectory = profiles[currentProfileName];
-    if (!currentProfileDirectory) {
-        console.error(`Unable to find current profile directory for \`${currentProfileName}\` profile.`);
-    }
-    const currentProfilePath = path.join(currentProfileDirectory, "settings.json");
-    await removeInheritedSettingsFromFile(currentProfilePath);
+export async function removeCurrentProfileInheritedSettings(
+  context: vscode.ExtensionContext,
+): Promise<void> {
+  const currentProfileName = await getCurrentProfileName(context);
+  const profiles = await getProfileMap(context);
+  const currentProfileDirectory = profiles[currentProfileName];
+  if (!currentProfileDirectory) {
+    console.error(
+      `Unable to find current profile directory for \`${currentProfileName}\` profile.`,
+    );
+  }
+  const currentProfilePath = path.join(
+    currentProfileDirectory,
+    "settings.json",
+  );
+  await removeInheritedSettingsFromFile(currentProfilePath);
 
-    // Also remove inherited extensions from the current profile's extensions.json
-    try {
-        const currentExtensionsPath = path.join(currentProfileDirectory, "extensions.json");
-        const currentExtensions = await readJSON(currentExtensionsPath) || [];
-        const filteredExtensions = currentExtensions.filter((ext: any) => {
-            return !ext?.metadata?.inheritedFromProfile;
-        });
-        // Only write if there was a change to avoid unnecessary fs writes
-        if (filteredExtensions.length !== currentExtensions.length) {
-            console.info(`Removing ${currentExtensions.length - filteredExtensions.length} inherited extensions from \`${currentExtensionsPath}\`.`);
-            await fs.writeFile(currentExtensionsPath, JSON.stringify(filteredExtensions, null, 4) + "\n", "utf8");
-        }
-    } catch (err) {
-        console.warn(`Failed to remove inherited extensions for profile \`${currentProfileName}\`:`, err);
+  // Also remove inherited extensions from the current profile's extensions.json
+  try {
+    const currentExtensionsPath = path.join(
+      currentProfileDirectory,
+      "extensions.json",
+    );
+    const currentExtensions = (await readJSON(currentExtensionsPath)) || [];
+    const filteredExtensions = currentExtensions.filter((ext: any) => {
+      return !ext?.metadata?.inheritedFromProfile;
+    });
+    // Only write if there was a change to avoid unnecessary fs writes
+    if (filteredExtensions.length !== currentExtensions.length) {
+      console.info(
+        `Removing ${currentExtensions.length - filteredExtensions.length} inherited extensions from \`${currentExtensionsPath}\`.`,
+      );
+      await fs.writeFile(
+        currentExtensionsPath,
+        JSON.stringify(filteredExtensions, null, 4) + "\n",
+        "utf8",
+      );
     }
+  } catch (err) {
+    console.warn(
+      `Failed to remove inherited extensions for profile \`${currentProfileName}\`:`,
+      err,
+    );
+  }
 
-    const config = vscode.workspace.getConfiguration("inheritProfile");
-    if (config.get<boolean>("showMessages", true)) {
-        vscode.window.showInformationMessage("Inherited settings remove from current profile!");
-    }
+  const config = vscode.workspace.getConfiguration("inheritProfile");
+  if (config.get<boolean>("showMessages", true)) {
+    vscode.window.showInformationMessage(
+      "Inherited settings remove from current profile!",
+    );
+  }
 }
 
 /**
  * Updates the inherited settings when the profile changes.
  * @param context Extension context.
  */
-export async function updateInheritedSettingsOnProfileChange(context: vscode.ExtensionContext) {
-    const globalStoragePath = getGlobalStoragePath(context);
-    let currentProfile = await getCurrentProfileName(context);
+export async function updateInheritedSettingsOnProfileChange(
+  context: vscode.ExtensionContext,
+) {
+  const globalStoragePath = getGlobalStoragePath(context);
+  let currentProfile = await getCurrentProfileName(context);
 
-    const watcher = vscode.workspace.createFileSystemWatcher(globalStoragePath);
-    const onChange = async () => {
-        const newProfileName = await getCurrentProfileName(context);
-        if (newProfileName !== currentProfile) {
-            currentProfile = newProfileName;
-            console.info("Current profile has changed, updating inherited settings...");
-            await updateCurrentProfileInheritance(context);
-        }
-    };
-    watcher.onDidChange(onChange);
-    watcher.onDidCreate(onChange);
-    watcher.onDidDelete(onChange);
+  const watcher = vscode.workspace.createFileSystemWatcher(globalStoragePath);
+  const onChange = async () => {
+    const newProfileName = await getCurrentProfileName(context);
+    if (newProfileName !== currentProfile) {
+      currentProfile = newProfileName;
+      console.info(
+        "Current profile has changed, updating inherited settings...",
+      );
+      await updateCurrentProfileInheritance(context);
+    }
+  };
+  watcher.onDidChange(onChange);
+  watcher.onDidCreate(onChange);
+  watcher.onDidDelete(onChange);
 
-    context.subscriptions.push(watcher);
+  context.subscriptions.push(watcher);
 }

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -743,7 +743,21 @@ async function applyInheritedSettings(context: vscode.ExtensionContext): Promise
 
     const currentExtensionsPath = path.join(currentProfileDirectory, "extensions.json");
     const currentExtensions = await readJSON(currentExtensionsPath) || [];
+    // Collect and write inherited extensions
+    const finalExtensions = await collectInheritedExtensions(currentExtensions, profiles);
+    console.info(`Writing ${finalExtensions.length} extensions to \`${currentExtensionsPath}\`.`);
+    await fs.writeFile(currentExtensionsPath, JSON.stringify(finalExtensions, null, 4) + "\n", "utf8");
+}
 
+/**
+ * Collect extensions from parent profiles, merge with current profile extensions,
+ * and mark inherited extensions in their metadata.
+ *
+ * @param currentProfileDirectory The directory path for the current profile.
+ * @param currentExtensions The parsed extensions array from the current profile.
+ * @returns The final extensions array to write back to the current profile.
+ */
+async function collectInheritedExtensions(currentExtensions: any[], profiles: Record<string, string>): Promise<any[]> {
     // Remove inherited extensions from the current profile, and convert to a map of id -> extension
     // Inherited extensions have the field `inheritedFromProfile` in their `metadata` object.
     const filteredExtensions = currentExtensions.filter((ext: any) => {
@@ -788,9 +802,7 @@ async function applyInheritedSettings(context: vscode.ExtensionContext): Promise
         }
     }
 
-    const finalExtensions = Object.values(extensionMap);
-    console.info(`Writing ${finalExtensions.length} extensions to \`${currentExtensionsPath}\`.`);
-    await fs.writeFile(currentExtensionsPath, JSON.stringify(finalExtensions, null, 4) + "\n", "utf8");
+    return Object.values(extensionMap);
 }
 
 /**
@@ -819,6 +831,22 @@ export async function removeCurrentProfileInheritedSettings(context: vscode.Exte
     }
     const currentProfilePath = path.join(currentProfileDirectory, "settings.json");
     await removeInheritedSettingsFromFile(currentProfilePath);
+
+    // Also remove inherited extensions from the current profile's extensions.json
+    try {
+        const currentExtensionsPath = path.join(currentProfileDirectory, "extensions.json");
+        const currentExtensions = await readJSON(currentExtensionsPath) || [];
+        const filteredExtensions = currentExtensions.filter((ext: any) => {
+            return !ext?.metadata?.inheritedFromProfile;
+        });
+        // Only write if there was a change to avoid unnecessary fs writes
+        if (filteredExtensions.length !== currentExtensions.length) {
+            console.info(`Removing ${currentExtensions.length - filteredExtensions.length} inherited extensions from \`${currentExtensionsPath}\`.`);
+            await fs.writeFile(currentExtensionsPath, JSON.stringify(filteredExtensions, null, 4) + "\n", "utf8");
+        }
+    } catch (err) {
+        console.warn(`Failed to remove inherited extensions for profile \`${currentProfileName}\`:`, err);
+    }
 
     const config = vscode.workspace.getConfiguration("inheritProfile");
     if (config.get<boolean>("showMessages", true)) {


### PR DESCRIPTION
Hi Alex! I found this extension very helpful as I wanted to implement something similar. I would like to submit this PR to address the current profile detection issue on platforms other than macOS, and to add the extension inheritance.

## Current Profile Detection

Reading `submenuitem.Profiles` for the current profile seems not working on Linux, as it doesn't exist (tested on KDE). Unfortunately vscode hasn't provided a reliable way to do this (see [this issue](https://github.com/microsoft/vscode/issues/211890)). Hence, as a fallback method, I added a similar way to the [`vscode-profile-status` plugin](https://github.com/robole/vscode-profile-status) to guess the current profile from the workspace URI and `profileAssociations` in the global storage. This doesn't work perfectly for certain scenarios, e.g. empty windows, and remote workspaces, where we fallback to `Default`.

## Extension Inheritance

I added extension inheritance to `applyInheritedSettings`. All inherited extensions will be tagged in their metadata, so they can be identified while updating or when removing inherited settings. This worked well on my environment, but I'm not sure if it would cause problems when synchronized across different platforms.

Thanks a lot for checking the PR. Feel free to let me know if you have any questions or suggestions.