### PR TITLE
fix: add emptyWindows fallback for profile detection in VS Code 1.127+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 <p align="center"><img width="25%" src="branding/icon_1024.png"/><img src="branding/name.png"/></p>
 <h3 align="center">Enables profile inheritance in VisualStudio Code!</h3>
-<h4 align="center"><a href="https://marketplace.visualstudio.com/items?itemName=alexthomson.inherit-profile" target="_blank">View in Marketplace</a></h3>
+<h4 align="center"><a href="https://marketplace.visualstudio.com/items?itemName=luotianyiismywife.inherit-profile-plus" target="_blank">View in Marketplace</a></h3>
+
+> **ℹ️ This is a community-maintained fork** with VS Code 1.127+ compatibility fixes.
+> [Original repo](https://github.com/alexjthomson/inherit-profile) by alexjthomson.
+>
+> **Extension ID:** `luotianyiismywife.inherit-profile-plus`
+>
+> **Install directly in VS Code:** Search for `Inherit Profile Plus` in the Extensions panel.
+
 <hr>
 
 ## ⚙️ Configuration

--- a/freture.md
+++ b/freture.md
@@ -1,0 +1,174 @@
+# 待实现功能
+
+> 上级（父 Profile）的配置要能集成到下级（子 Profile），包括扩展和设置。
+> 当下级与上级配置有冲突时，以下级为准（子覆盖父）。
+
+---
+
+## 现有代码分析
+
+### 当前已实现的部分
+
+现有代码在 `src/profiles.ts` 和 `src/profileSettings.ts` 中已有继承基础：
+
+| 机制 | 实现 |
+|------|------|
+| 父 Profile 声明 | `inheritProfile.parents` 配置项（如 `["Base"]`） |
+| 设置继承 | `getInheritedSettings()` + `subtractSettings(parent, child)` → 子已有的设置不会被父覆盖 ✅ |
+| 扩展继承 | `collectInheritedExtensions()` → 将父扩展标记 `metadata.inheritedFromProfile` 后合并到子 |
+| 触发时机 | 启动时（`runOnStartup`）+ 切换 Profile 时（`runOnProfileChange`） |
+
+**冲突策略（子覆盖父）在现有代码中已正确实现：**
+- 设置：`subtractSettings()` 会跳过子 Profile 已有的 key
+- 扩展：`collectInheritedExtensions()` 以子 Profile 已有的扩展 ID 为准，跳过重复项
+
+### 存在的问题
+
+1. **两套同步机制不统一**
+   - Dev 使用 `inheritProfile.parents` 机制（带 `inheritedFromProfile` 标记）
+   - Writing 是**直接复制** Base 的 `extensions.json`（无标记），导致修改 Base 后不同步
+
+2. **只有"拉"没有"推"**
+   - 仅在**当前** Profile 切换/启动时触发同步
+   - 修改父 Profile 后，子 Profile 不会自动感知更新（除非切换到子 Profile）
+
+3. **父删除扩展时，子会残留**
+   - 如果子 Profile 的扩展是直接复制的（无 `inheritedFromProfile` 标记），父删除后子不会自动清理
+   - 带标记的扩展会被过滤后重新从父收集，所以能正确同步删除 ✅
+
+4. **没有 Profile 关系注册表**
+   - 目前不知道哪些子 Profile 继承了哪些父 Profile
+   - 需要从所有 Profile 的 settings.json 中读取 `inheritProfile.parents` 来推算
+
+---
+
+## 实现方案
+
+### Phase 1：统一继承机制（优先级最高）
+
+**目标：** 所有子 Profile 统一使用 `inheritProfile.parents` + `inheritedFromProfile` 标记机制
+
+**改动点：**
+
+```
+Writing Profile
+  ├── settings.json: 保留 inheritProfile.parents: ["Base"]
+  └── extensions.json: 从"直接复制 Base" → "标记继承"
+      即：第一次同步时，给所有来自 Base 的扩展打上 inheritedFromProfile 标记
+```
+
+具体实现：
+- 在 `updateCurrentProfileInheritance()` 中增加判断：如果子 Profile 的扩展数几乎等于父 Profile（且无 inheritedFromProfile 标记），说明是"复制模式"，自动转换为"继承标记模式"
+- 或者提供一条迁移命令，手动转换
+
+### Phase 2：扩展合并增强（完整继承语义）
+
+**当前** `collectInheritedExtensions()` 的逻辑：
+
+```
+1. 过滤掉子中标记了 inheritedFromProfile 的扩展
+2. 从父收集扩展，不在子中的就标记 inheritedFromProfile 后加入
+```
+
+**行为分析**（已符合需求）：
+
+| 场景 | 结果 |
+|------|------|
+| 父有、子无 | ✅ 继承到子（标记 inheritedFromProfile） |
+| 父有、子也有 | ✅ 以子为准（跳过不覆盖） |
+| 父无、子有（自有） | ✅ 保留子扩展 |
+| 父无、子有（曾继承） | ✅ 被过滤掉，再从父收集不到，自然删除 |
+
+**结论：** Phase 2 已有正确实现，只需保证所有子 Profile 都使用此机制即可。
+
+### Phase 3：级联同步（父→子推送）
+
+**目标：** 修改父 Profile 后，所有子 Profile 自动同步更新。
+
+**方案：监听父 Profile 的 extensions.json/settings.json 变化**
+
+```
+在 updateInheritedSettingsOnProfileChange() 中增强：
+
+1. 扫描所有 Profile 的 settings.json
+2. 找出哪些 Profile 的 inheritProfile.parents 包含当前修改的 Profile
+3. 遍历这些子 Profile，依次调用 applyInheritedSettings()
+```
+
+**伪代码：**
+
+```typescript
+async function cascadeSyncToChildren(context, changedProfileName) {
+  const allProfiles = await getProfileMap(context);
+  
+  for (const [profileName, profileDir] of Object.entries(allProfiles)) {
+    const settingsPath = path.join(profileDir, "settings.json");
+    const settings = await readJSON(settingsPath);
+    const parents = settings?.inheritProfile?.parents ?? [];
+    
+    if (parents.includes(changedProfileName)) {
+      // 触发子 Profile 的继承同步
+      await applyInheritedSettingsForProfile(context, profileName, profileDir);
+    }
+  }
+}
+```
+
+**触发时机：**
+
+| 方式 | 说明 |
+|------|------|
+| 监听父 Profile 文件变化 | 用 `FileSystemWatcher` 监听配置文件变更 |
+| 继承同步完成后级联 | 当前 Profile 同步完后，自动触发其子 Profile 的同步 |
+| 手动命令 | 提供 "Sync inheritance for all profiles" 命令 |
+
+### Phase 4：设置合并迁移——从 "subtract" 到 "显式合并块"
+
+**当前实现**：用 `subtractSettings()` 剔除子已有的设置，只写缺失的部分到 inherited 块。
+
+**这是正确的✅**，但有一个局限：
+
+```
+父 settings.json:
+  { "editor.fontSize": 14, "editor.tabSize": 4 }
+
+子 settings.json（当前）:
+  { "editor.fontSize": 16 }
+
+继承结果：
+  子 inherited 块 → { "editor.tabSize": 4 }
+  子最终可见     → { "editor.fontSize": 16, "editor.tabSize": 4 }  ← ✅ 正确
+```
+
+但如果父修改了 `editor.tabSize: 4 → 6`，当前机制能检测到变化吗？
+
+**验证：** `getInheritedSettings()` → `subtractSettings(parentSettings, currentChildSettings)` → 只要子没有显式定义 `editor.tabSize`，就会从父拿到新值。**✅ 能同步更新。**
+
+**结论：** Phase 4 当前已正确实现，无需改动。
+
+### Phase 5：Profile 关系可视化
+
+**目标：** 在状态栏或树视图中显示当前的继承链路。
+
+可选的增强功能：
+- 在 `profiles.ts` 中新增函数 `getInheritanceTree()`，返回 Profile 的继承关系树
+- 在 VS Code 状态栏显示当前 Profile 的名称和父 Profile
+- 提供一个树视图，展示所有 Profile 的继承关系
+
+---
+
+## 实现路线图
+
+| 优先级 | 阶段 | 工作量 | 说明 |
+|--------|------|--------|------|
+| 🔴 P0 | Phase 1: 统一继承机制 | 小 | Writing 从复制模式迁移到标记模式 |
+| 🟡 P1 | Phase 3: 级联同步 | 中 | 父 Profile 变更时触发子更新 |
+| 🟢 P2 | Phase 5: 关系可视化 | 小 | 可选增强功能 |
+
+## 技术关键点
+
+1. **避免同步循环**：A 继承 B，B 继承 A → 需要检测循环依赖
+2. **文件写入节流**：批量修改时避免频繁写盘
+3. **用户通知**：后台同步完成后通知用户变更情况
+4. **出错不回退**：某个子 Profile 同步失败不应影响其他子 Profile
+- 目前 `inherit-profile-plus` 的行为是单向追加（新增同步，删除不同步），后续需改为完整的继承合并模型

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inherit-profile",
-  "version": "0.5.5",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inherit-profile",
-      "version": "0.5.5",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.3.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "inherit-profile",
+  "name": "inherit-profile-plus",
   "version": "0.7.0",
-  "displayName": "Inherit Profile (Community Fork)",
+  "displayName": "Inherit Profile Plus",
   "description": "Profile inheritance for VS Code. Community fork with VS Code 1.127+ fixes.",
   "icon": "branding/icon_128.png",
   "publisher": "luotianyiismywife",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "inherit-profile",
-  "version": "0.6.0",
-  "displayName": "Inherit Profile",
-  "description": "Profile inheritance for VS Code.",
+  "version": "0.7.0",
+  "displayName": "Inherit Profile (Community Fork)",
+  "description": "Profile inheritance for VS Code. Community fork with VS Code 1.127+ fixes.",
   "icon": "branding/icon_128.png",
-  "publisher": "alexthomson",
+  "publisher": "luotianyiismywife",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alexjthomson/inherit-profile"
+    "url": "https://github.com/luotianyiismywife/inherit-profile"
   },
   "license": "MIT",
   "engines": {
@@ -30,9 +30,9 @@
     "configs",
     "workspace"
   ],
-  "homepage": "https://github.com/alexjthomson/inherit-profile#readme",
+  "homepage": "https://github.com/luotianyiismywife/inherit-profile#readme",
   "bugs": {
-    "url": "https://github.com/alexjthomson/inherit-profile/issues"
+    "url": "https://github.com/luotianyiismywife/inherit-profile/issues"
   },
   "galleryBanner": {
     "color": "#1e1e1e",

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -179,6 +179,27 @@ async function getCurrentProfileName(
       return profile?.name || "Default";
     }
   }
+
+  // Fallback for empty windows (no workspace/folder open):
+  // In VS Code 1.127+, the profile menu structure is no longer in storage.json.
+  // Use the current window's backup folder ID to look up the profile association.
+  const lastActiveWindow = storage.windowsState?.lastActiveWindow;
+  if (lastActiveWindow?.backupPath) {
+    const backupFolderId = path.basename(lastActiveWindow.backupPath);
+    const emptyWindows = storage.profileAssociations?.emptyWindows;
+    if (emptyWindows && Object.prototype.hasOwnProperty.call(emptyWindows, backupFolderId)) {
+      const profileId = emptyWindows[backupFolderId];
+      const profile = findByKeyValuePair(
+        storage.userDataProfiles,
+        "location",
+        profileId,
+      );
+      if (profile?.name) {
+        return profile.name;
+      }
+    }
+  }
+
   return "Default";
 }
 

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -187,7 +187,10 @@ async function getCurrentProfileName(
   if (lastActiveWindow?.backupPath) {
     const backupFolderId = path.basename(lastActiveWindow.backupPath);
     const emptyWindows = storage.profileAssociations?.emptyWindows;
-    if (emptyWindows && Object.prototype.hasOwnProperty.call(emptyWindows, backupFolderId)) {
+    if (
+      emptyWindows &&
+      Object.prototype.hasOwnProperty.call(emptyWindows, backupFolderId)
+    ) {
       const profileId = emptyWindows[backupFolderId];
       const profile = findByKeyValuePair(
         storage.userDataProfiles,

--- a/vscode配置文件及其配置明细.md
+++ b/vscode配置文件及其配置明细.md
@@ -1,0 +1,252 @@
+# VS Code Profile 体系 · 完整架构文档
+
+> 最后更新: 2026-07-08
+
+---
+
+## 一、整体架构
+
+```
+Base（通用底座·21个）
+├── Base->Dev（通用开发工具·56个）
+└── Base->Writing（文字写作·21个，自动继承 Base）
+
+Test（未归类文档工具，3个，仅文档规划）
+```
+
+---
+
+## 二、Profile 明细
+
+### 2.1 Base · 通用底座（21 个扩展）
+
+**UUID:** `10a9f58d`
+
+**继承:** 无（根 Profile）
+
+**Settings:**
+
+```json
+{
+    "inheritProfile.runOnProfileChange": true,
+    "gitlens.ai.model": "vscode",
+    "gitlens.ai.vscode.model": "opencode-go:minimax",
+    "diffEditor.renderSideBySide": false,
+    "chat.agent.maxRequests": 300,
+    "opencodego.enableZenFreeModels": true,
+    "explorer.confirmDelete": false,
+    "chat.utilitySmallModel": "opencodego/deepseek-v4-flash"
+}
+```
+
+> ⚠️ 注意：Base 是根 Profile，`inheritProfile.runOnProfileChange` 不会产生实际影响（无父 Profile 可继承）
+
+**扩展列表:**
+
+| 扩展 ID                                   | 名称                 | 用途                  |
+| ----------------------------------------- | -------------------- | --------------------- |
+| `ms-vscode-remote.remote-ssh`             | Remote - SSH         | SSH 远程连接          |
+| `ms-vscode.remote-explorer`               | Remote Explorer      | 远程资源管理器        |
+| `ms-vscode-remote.remote-ssh-edit`        | Remote SSH: Edit     | SSH Config 编辑       |
+| `eamodio.gitlens`                         | GitLens              | Git 增强              |
+| `github.codespaces`                       | GitHub Codespaces    | 云端开发              |
+| `github.vscode-pull-request-github`       | GitHub Pull Requests | PR 管理               |
+| `ms-ceintl.vscode-language-pack-zh-hans`  | Chinese (Simplified) | 中文汉化              |
+| `vscode-icons-team.vscode-icons`          | vscode-icons         | 文件图标主题          |
+| `vizards.deepseek-v4-for-copilot`         | DeepSeek V4          | Copilot 模型          |
+| `denizhandaklr.glm-chat-provider`         | GLM Chat             | Copilot 模型          |
+| `denizhandaklr.kimi-lm-provider`          | Kimi                 | Copilot 模型          |
+| `denizhandaklr.minimax-vscode`            | MiniMax              | Copilot 模型          |
+| `kisstkondoros.vscode-gutter-preview`     | Image preview        | 图片预览              |
+| `luotianyiismywife.ghcp-dashboard`        | GHCP Dashboard       | GitHub Copilot 仪表盘 |
+| `luotianyiismywife.inherit-profile-plus`  | Inherit Profile Plus | 继承工具              |
+| `onesoftqwq.opencode-go-copilot-provider` | OpenCode Go          | Copilot 适配          |
+| `yzhang.markdown-all-in-one`              | Markdown All in One  | Markdown 增强         |
+| `mushan.vscode-paste-image`               | Paste Image          | 粘贴图片              |
+| `davidanson.vscode-markdownlint`          | markdownlint         | Markdown 规范检查     |
+| `shd101wyy.markdown-preview-enhanced`     | Markdown Preview Enhanced | Markdown 增强预览 |
+| `maxdavidwow.remix-light`                 | Remix Light          | 浅色主题              |
+
+---
+
+### 2.2 Base->Dev · 通用开发（56 个扩展，含继承自 Base）
+
+**UUID:** `-367578e4`
+
+**继承:** `inheritProfile.parents: ["Base"]`
+
+**Settings:**
+
+```json
+{
+    "inheritProfile.parents": ["Base"],
+    "inheritProfile.runOnStartup": true,
+    "inheritProfile.runOnProfileChange": true,
+    "inheritProfile.showMessages": false,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "gitlens.ai.model": "vscode",
+    "gitlens.ai.vscode.model": "copilotcli:"
+}
+```
+
+> ⚠️ 子 Profile 中还包含继承自 Base 的 inherited settings 块（由 `inherit-profile-plus` 自动管理），此处不重复列出
+
+**扩展列表:**
+
+| 扩展 ID                                  | 名称                       | 用途              |
+| ---------------------------------------- | -------------------------- | ----------------- |
+| `esbenp.prettier-vscode`                 | Prettier                   | 跨语言格式化      |
+| `usernamehw.errorlens`                   | Error Lens                 | 内联错误提示      |
+| `fill-labs.dependi`                      | Dependi                    | 跨语言依赖管理    |
+| `gerrnperl.outline-map`                  | Outline Map                | 代码大纲图        |
+| `vadimcn.vscode-lldb`                    | CodeLLDB                   | 调试器            |
+| `redhat.vscode-xml`                      | XML                        | XML 支持          |
+| `luotianyiismywife.inherit-profile-plus` | Inherit Profile Plus       | 继承工具          |
+| `ms-python.python`                       | Python                     | Python 语言支持   |
+| `ms-python.debugpy`                      | Python Debugger            | Python 调试器     |
+| `ms-python.vscode-pylance`               | Pylance                    | Python 语言服务   |
+| `ms-python.vscode-python-envs`           | Python Environment Manager | Python 环境管理   |
+| `golang.go`                              | Go                         | Go 语言支持       |
+| `redhat.java`                            | Language Support for Java  | Java 语言支持     |
+| `vscjava.vscode-java-debug`              | Debugger for Java          | Java 调试器       |
+| `vscjava.vscode-java-dependency`         | Java Dependency Viewer     | Java 依赖管理     |
+| `vscjava.vscode-java-pack`               | Extension Pack for Java    | Java 扩展包       |
+| `vscjava.vscode-java-test`               | Java Test Runner           | Java 测试         |
+| `vscjava.vscode-maven`                   | Maven for Java             | Maven 支持        |
+| `vscjava.vscode-gradle`                  | Gradle for Java            | Gradle 支持       |
+| `ecmel.vscode-html-css`                  | HTML CSS Support           | HTML/CSS 补全     |
+| `xabikos.javascriptsnippets`             | JavaScript (ES6) Snippets  | JS 代码片段       |
+| `formulahendry.auto-rename-tag`          | Auto Rename Tag            | HTML 标签同步改名 |
+| `pranaygp.vscode-css-peek`               | CSS Peek                   | CSS 定义跳转      |
+| `sporiley.css-auto-prefix`               | CSS Auto Prefix            | CSS 前缀补全      |
+| `vincaslt.highlight-matching-tag`        | Highlight Matching Tag     | 标签高亮          |
+| `foxundermoon.shell-format`              | shell-format               | Shell 格式化      |
+| `ritwickdey.liveserver`                  | Live Server                | 本地开发服务器    |
+| `firefox-devtools.vscode-firefox-debug`  | Firefox Debugger           | Firefox 调试      |
+| `ms-edgedevtools.vscode-edge-devtools`   | Edge DevTools              | Edge 调试         |
+| `tamasfe.even-better-toml`               | Even Better TOML           | TOML 支持         |
+| `ms-vscode.powershell`                   | PowerShell                 | PowerShell 支持   |
+| `rust-lang.rust-analyzer`                | rust-analyzer              | Rust 语言支持     |
+| `barbosshack.crates-io`                  | crates-io                  | Rust Crate 管理   |
+| `gitlab.gitlab-workflow`                 | GitLab Workflow            | GitLab 集成       |
+| `ms-dotnettools.vscode-dotnet-runtime`   | .NET Runtime               | .NET 运行时       |
+
+### 2.4 Base->Writing · 文字写作（21 个扩展，含继承自 Base，由 inherit-profile-plus 自动管理）
+
+**UUID:** `-332dce57`
+
+**继承:** `inheritProfile.parents: ["Base"]`
+
+**Settings:**
+
+```json
+{
+    "inheritProfile.parents": ["Base"],
+    "inheritProfile.runOnStartup": true,
+    "inheritProfile.runOnProfileChange": true,
+    "git.autofetch": true
+}
+```
+
+> ⚠️ 子 Profile 中还包含继承自 Base 的 inherited settings 块（由 `inherit-profile-plus` 自动管理），此处不重复列出
+
+**扩展列表:**
+
+与 **Base** 完全一致（21 个），由 `inherit-profile-plus` 在启动/切 Profile 时自动同步。无需手动维护。
+
+---
+
+---
+
+### 2.5 Default Profile（57 个扩展 · 全局存储）
+
+**UUID:** `__default__profile__`（特殊，无独立目录）
+
+**Settings**（12 项，仅保留语言相关 + 扩展专用）:
+
+```json
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "liveServer.settings.donotShowInfoMsg": true,
+  "[python]": { "editor.formatOnType": true },
+  "[shellscript]": { "editor.defaultFormatter": "foxundermoon.shell-format" },
+  "[go]": { "editor.defaultFormatter": "golang.go" },
+  "[rust]": {},
+  "redhat.telemetry.enabled": true,
+  "cmake.configureOnOpen": true,
+  "vscode-edge-devtools.webhintInstallNotification": true,
+  "wikitext.autoLogin": "Never",
+  "lldb.dbgconfig": {},
+  "window.newWindowProfile": "Base->Dev"
+}
+```
+
+**扩展列表（57 个）** — 全局安装，所有 Profile 可见，但各 Profile 的 `extensions.json` 决定哪些启用。
+
+| 类别          | 扩展                                                                                                                                                                                                                                 |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 🔀 Git        | `eamodio.gitlens`, `github.codespaces`, `github.vscode-pull-request-github`                                                                                                                                                          |
+| 🌏 汉化       | `ms-ceintl.vscode-language-pack-zh-hans`                                                                                                                                                                                             |
+| 🎨 美化       | `vscode-icons-team.vscode-icons`, `maxdavidwow.remix-light`                                                                                                                                                                          |
+| 🔌 远程       | `ms-vscode-remote.remote-ssh`, `ms-vscode.remote-explorer`, `ms-vscode-remote.remote-ssh-edit`                                                                                                                                       |
+| 📝 Markdown   | `yzhang.markdown-all-in-one`, `shd101wyy.markdown-preview-enhanced`, `davidanson.vscode-markdownlint`                                                                                                                                |
+| 🖼️ 工具       | `kisstkondoros.vscode-gutter-preview`, `mushan.vscode-paste-image`                                                                                                                                                                   |
+| 🐍 Python     | `ms-python.python`, `ms-python.debugpy`, `ms-python.vscode-pylance`, `ms-python.vscode-python-envs`                                                                                                                                  |
+| 🐹 Go         | `golang.go`                                                                                                                                                                                                                          |
+| ☕ Java       | `redhat.java`, `vscjava.vscode-java-debug`, `vscjava.vscode-java-dependency`, `vscjava.vscode-java-pack`, `vscjava.vscode-java-test`, `vscjava.vscode-maven`, `vscjava.vscode-gradle`                                                |
+| 🌐 前端       | `ecmel.vscode-html-css`, `xabikos.javascriptsnippets`, `formulahendry.auto-rename-tag`, `pranaygp.vscode-css-peek`, `sporiley.css-auto-prefix`, `vincaslt.highlight-matching-tag`, `esbenp.prettier-vscode`, `ritwickdey.liveserver` |
+| 🔧 工具       | `foxundermoon.shell-format`, `vadimcn.vscode-lldb`, `tamasfe.even-better-toml`, `redhat.vscode-xml`, `sergey-tihon.openxml-explorer`                                                                                                 |
+| 🔥 调试       | `firefox-devtools.vscode-firefox-debug`, `ms-edgedevtools.vscode-edge-devtools`                                                                                                                                                      |
+| 🤖 Git 平台   | `gitlab.gitlab-workflow`                                                                                                                                                                                                             |
+| 📄 文档       | `rowewilsonfrederiskholme.wikitext`, `yuenm18.ooxml-viewer`                                                                                                                                                                          |
+| ⚙️ 其他       | `ms-dotnettools.vscode-dotnet-runtime`                                                                                                                                                                                               |
+| 🖥️ PowerShell | `ms-vscode.powershell`                                                                                                                                                                                                              |
+
+---
+
+### 2.6 未归类扩展（3 个 · 未加入任何自定义 Profile）
+
+**说明:** 以下扩展全局已安装，但未加入 Base/Dev/Writing 任一自定义 Profile。仅在 Default Profile 中可用。
+
+| 扩展 ID | 名称 | 用途 |
+|---------|------|------|
+| `rowewilsonfrederiskholme.wikitext` | WikiText | Wiki 文档编辑 |
+| `sergey-tihon.openxml-explorer` | OpenXML Explorer | Office XML 查看器 |
+| `yuenm18.ooxml-viewer` | OOXML Viewer | OOXML 文件查看 |
+
+---
+
+## 三、继承关系图
+
+```mermaid
+graph TB
+    Base["Base (21个)"]
+    Dev["Base->Dev (56个)<br/>prettier, errorlens, dependi<br/>+Python, Go, Java, 前端<br/>+lldb, xml, shell, debug<br/>+PowerShell, Rust, .NET, GitLab"]
+    Writing["Base->Writing (21个)<br/>自动继承 Base"]
+
+    Base -->|inherit| Dev
+    Base -->|inherit| Writing
+```
+
+---
+
+## 五、关键文件路径
+
+| 内容             | 路径                                                                  |
+| ---------------- | --------------------------------------------------------------------- |
+| Profile 目录     | `%APPDATA%\Code\User\profiles\`                                       |
+| Profile 注册表   | `%APPDATA%\Code\User\globalStorage\storage.json` → `userDataProfiles` |
+| 全局扩展安装目录 | `%USERPROFILE%\.vscode\extensions\`                                   |
+| 全局扩展清单     | `%USERPROFILE%\.vscode\extensions\extensions.json`                    |
+| 用户设置         | `%APPDATA%\Code\User\settings.json`                                   |
+| Profile 缓存     | `%APPDATA%\Code\CachedProfilesData\`                                  |
+| state 数据库     | `%APPDATA%\Code\User\globalStorage\state.vscdb`                       |
+
+---
+
+## 六、注意事项
+
+1. **Profile 注册信息存在 SQLite 数据库中**（`state.vscdb`），手动改 `storage.json` 会在重启时被覆盖
+2. **扩展文件在全局**（`extensions/`），Profile 的 `extensions.json` 只是"引用清单"
+3. **`inherit-profile-plus` 扩展** 需要在子 Profile 中也安装才能工作
+4. **Profile 名称中的 `->`** 只是命名约定，无实际语义

--- a/vscode配置文件及其配置明细.md
+++ b/vscode配置文件及其配置明细.md
@@ -7,9 +7,9 @@
 ## 一、整体架构
 
 ```
-Base（通用底座·21个）
+Base（通用底座·20个）
 ├── Base->Dev（通用开发工具·56个）
-└── Base->Writing（文字写作·21个，自动继承 Base）
+└── Base->Writing（文字写作·20个，自动继承 Base）
 
 Test（未归类文档工具，3个，仅文档规划）
 ```
@@ -18,7 +18,7 @@ Test（未归类文档工具，3个，仅文档规划）
 
 ## 二、Profile 明细
 
-### 2.1 Base · 通用底座（21 个扩展）
+### 2.1 Base · 通用底座（20 个扩展）
 
 **UUID:** `10a9f58d`
 
@@ -45,9 +45,6 @@ Test（未归类文档工具，3个，仅文档规划）
 
 | 扩展 ID                                   | 名称                 | 用途                  |
 | ----------------------------------------- | -------------------- | --------------------- |
-| `ms-vscode-remote.remote-ssh`             | Remote - SSH         | SSH 远程连接          |
-| `ms-vscode.remote-explorer`               | Remote Explorer      | 远程资源管理器        |
-| `ms-vscode-remote.remote-ssh-edit`        | Remote SSH: Edit     | SSH Config 编辑       |
 | `eamodio.gitlens`                         | GitLens              | Git 增强              |
 | `github.codespaces`                       | GitHub Codespaces    | 云端开发              |
 | `github.vscode-pull-request-github`       | GitHub Pull Requests | PR 管理               |
@@ -65,7 +62,6 @@ Test（未归类文档工具，3个，仅文档规划）
 | `mushan.vscode-paste-image`               | Paste Image          | 粘贴图片              |
 | `davidanson.vscode-markdownlint`          | markdownlint         | Markdown 规范检查     |
 | `shd101wyy.markdown-preview-enhanced`     | Markdown Preview Enhanced | Markdown 增强预览 |
-| `maxdavidwow.remix-light`                 | Remix Light          | 浅色主题              |
 
 ---
 
@@ -95,6 +91,9 @@ Test（未归类文档工具，3个，仅文档规划）
 
 | 扩展 ID                                  | 名称                       | 用途              |
 | ---------------------------------------- | -------------------------- | ----------------- |
+| `ms-vscode-remote.remote-ssh`            | Remote - SSH               | SSH 远程连接      |
+| `ms-vscode.remote-explorer`              | Remote Explorer            | 远程资源管理器    |
+| `ms-vscode-remote.remote-ssh-edit`       | Remote SSH: Edit           | SSH Config 编辑   |
 | `esbenp.prettier-vscode`                 | Prettier                   | 跨语言格式化      |
 | `usernamehw.errorlens`                   | Error Lens                 | 内联错误提示      |
 | `fill-labs.dependi`                      | Dependi                    | 跨语言依赖管理    |
@@ -131,7 +130,7 @@ Test（未归类文档工具，3个，仅文档规划）
 | `gitlab.gitlab-workflow`                 | GitLab Workflow            | GitLab 集成       |
 | `ms-dotnettools.vscode-dotnet-runtime`   | .NET Runtime               | .NET 运行时       |
 
-### 2.4 Base->Writing · 文字写作（21 个扩展，含继承自 Base，由 inherit-profile-plus 自动管理）
+### 2.4 Base->Writing · 文字写作（20 个扩展，含继承自 Base，由 inherit-profile-plus 自动管理）
 
 **UUID:** `-332dce57`
 
@@ -152,13 +151,13 @@ Test（未归类文档工具，3个，仅文档规划）
 
 **扩展列表:**
 
-与 **Base** 完全一致（21 个），由 `inherit-profile-plus` 在启动/切 Profile 时自动同步。无需手动维护。
+与 **Base** 完全一致（20 个），由 `inherit-profile-plus` 在启动/切 Profile 时自动同步。无需手动维护。
 
 ---
 
 ---
 
-### 2.5 Default Profile（57 个扩展 · 全局存储）
+### 2.5 Default Profile（56 个扩展 · 全局存储）
 
 **UUID:** `__default__profile__`（特殊，无独立目录）
 
@@ -181,13 +180,13 @@ Test（未归类文档工具，3个，仅文档规划）
 }
 ```
 
-**扩展列表（57 个）** — 全局安装，所有 Profile 可见，但各 Profile 的 `extensions.json` 决定哪些启用。
+**扩展列表（56 个）** — 全局安装，所有 Profile 可见，但各 Profile 的 `extensions.json` 决定哪些启用。
 
 | 类别          | 扩展                                                                                                                                                                                                                                 |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | 🔀 Git        | `eamodio.gitlens`, `github.codespaces`, `github.vscode-pull-request-github`                                                                                                                                                          |
 | 🌏 汉化       | `ms-ceintl.vscode-language-pack-zh-hans`                                                                                                                                                                                             |
-| 🎨 美化       | `vscode-icons-team.vscode-icons`, `maxdavidwow.remix-light`                                                                                                                                                                          |
+| 🎨 美化       | `vscode-icons-team.vscode-icons`                                                                                                                                                                          |
 | 🔌 远程       | `ms-vscode-remote.remote-ssh`, `ms-vscode.remote-explorer`, `ms-vscode-remote.remote-ssh-edit`                                                                                                                                       |
 | 📝 Markdown   | `yzhang.markdown-all-in-one`, `shd101wyy.markdown-preview-enhanced`, `davidanson.vscode-markdownlint`                                                                                                                                |
 | 🖼️ 工具       | `kisstkondoros.vscode-gutter-preview`, `mushan.vscode-paste-image`                                                                                                                                                                   |
@@ -220,9 +219,9 @@ Test（未归类文档工具，3个，仅文档规划）
 
 ```mermaid
 graph TB
-    Base["Base (21个)"]
+    Base["Base (20个)"]
     Dev["Base->Dev (56个)<br/>prettier, errorlens, dependi<br/>+Python, Go, Java, 前端<br/>+lldb, xml, shell, debug<br/>+PowerShell, Rust, .NET, GitLab"]
-    Writing["Base->Writing (21个)<br/>自动继承 Base"]
+    Writing["Base->Writing (20个)<br/>自动继承 Base"]
 
     Base -->|inherit| Dev
     Base -->|inherit| Writing
@@ -250,3 +249,165 @@ graph TB
 2. **扩展文件在全局**（`extensions/`），Profile 的 `extensions.json` 只是"引用清单"
 3. **`inherit-profile-plus` 扩展** 需要在子 Profile 中也安装才能工作
 4. **Profile 名称中的 `->`** 只是命名约定，无实际语义
+
+---
+
+## 七、修改本地扩展的工作流程
+
+> **核心理念：** 一个扩展的改动需要同步 **两处**——本 Markdown 文档 + 实际 Profile 的 `extensions.json` 文件。
+
+### 7.1 常见场景
+
+| 场景 | 说明 |
+|------|------|
+| **新增扩展** | 安装后加入指定 Profile 的扩展清单 |
+| **移除扩展** | 从某 Profile 取消勾选（卸载则全局移除） |
+| **跨 Profile 移动** | 从 A Profile 移到 B Profile（如 Base → Dev） |
+
+### 7.2 修改步骤
+
+#### 步骤一：更新本 Markdown 文档
+
+找到文档中对应的 Profile 表格，执行以下操作：
+
+- **新增**：在表格末尾追加一行 `\| <扩展ID> \| <名称> \| <用途> \|`
+- **删除**：移除该扩展所在的行
+- **移动**：从源 Profile 表格删除，在目标 Profile 表格中添加
+
+同时更新以下受影响的计数值：
+
+| 位置 | 需同步 |
+|------|--------|
+| 一、整体架构（Base/Dev/Writing 个数） | Base/Writing 增减时更新 |
+| 各 Profile 标题括号内的个数 | 对应 Profile 增减时更新 |
+| Base->Writing 说明文字中的个数 | Base 增减时同步更新 |
+| Default Profile 标题与描述中的个数 | 全局扩展总数变化时更新 |
+| 三、Mermaid 继承关系图 | Base/Writing 个数变化时更新 |
+
+#### 步骤二：更新本地 Profile 文件
+
+找到对应 Profile 目录下的 `extensions.json`：
+
+```
+%APPDATA%\Code\User\profiles\<UUID>\extensions.json
+```
+
+| Profile | UUID 目录 |
+|---------|-----------|
+| Base | `10a9f58d` |
+| Base->Dev | `-367578e4` |
+| Base->Writing | `-332dce57` |
+
+**JSON 结构说明：**
+
+```json
+{
+  "identifier": {
+    "id": "publisher.extension-name",
+    "uuid": "全局唯一标识"
+  },
+  "version": "x.y.z",
+  "location": { "$mid": 1, "path": "扩展安装路径", "scheme": "file" },
+  "relativeLocation": "publisher.extension-name-x.y.z",
+  "metadata": {
+    "installedTimestamp": 时间戳,
+    "pinned": false,
+    "source": "gallery",
+    "id": "uuid",
+    "publisherId": "uuid",
+    "publisherDisplayName": "发布者",
+    "targetPlatform": "undefined",
+    "updated": false,
+    "private": false,
+    "isPreReleaseVersion": false,
+    "hasPreReleaseVersion": false,
+    "preRelease": false
+  }
+}
+```
+
+操作方式（任选其一）：
+
+<details>
+<summary><b>方式 A：使用 PowerShell 脚本（推荐，精确可靠）</b></summary>
+
+```powershell
+# 读取
+$profilePath = "$env:APPDATA\Code\User\profiles\<UUID>\extensions.json"
+$ext = Get-Content $profilePath -Raw | ConvertFrom-Json
+
+# 新增：先在 VS Code 安装扩展，再从全局已安装清单中找到其完整对象
+# 查看全局清单：%USERPROFILE%\.vscode\extensions\extensions.json
+$globalExt = Get-Content "$env:USERPROFILE\.vscode\extensions\extensions.json" -Raw | ConvertFrom-Json
+$newExt = $globalExt | Where-Object { $_.identifier.id -eq "publisher.extension-name" }
+$ext = $ext + $newExt   # 追加到末尾
+
+# 删除：按 identifier.id 过滤排除
+$ext = $ext | Where-Object { $_.identifier.id -ne "publisher.extension-name" }
+
+# 写出（-Compress 保持单行紧凑格式）
+$ext | ConvertTo-Json -Depth 10 -Compress | Set-Content $profilePath -Encoding UTF8
+```
+</details>
+
+<details>
+<summary><b>方式 B：手动编辑（少量修改时可用）</b></summary>
+
+1. 在 VS Code 中打开 `%APPDATA%\Code\User\profiles\<UUID>\extensions.json`
+2. 按 JSON 格式增删对应的扩展对象（注意数组逗号）
+3. 保存文件
+</details>
+
+#### 步骤三：验证
+
+```powershell
+# 检查某扩展是否存在于 Profile 中
+Select-String -Path "$env:APPDATA\Code\User\profiles\10a9f58d\extensions.json" -Pattern "extension-name" -SimpleMatch
+
+# 统计 Profile 扩展数量
+(Get-Content "$env:APPDATA\Code\User\profiles\10a9f58d\extensions.json" -Raw | ConvertFrom-Json).Count
+```
+
+### 7.3 典型操作示例
+
+#### 例：新增一个扩展到 Dev
+
+```powershell
+$devPath = "$env:APPDATA\Code\User\profiles\-367578e4\extensions.json"
+$devExt = Get-Content $devPath -Raw | ConvertFrom-Json
+
+# 从全局已安装清单中找到目标扩展
+$globalExt = Get-Content "$env:USERPROFILE\.vscode\extensions\extensions.json" -Raw | ConvertFrom-Json
+$newExt = $globalExt | Where-Object { $_.identifier.id -eq "publisher.new-extension" }
+
+# 追加并写出
+$devExt = $devExt + $newExt
+$devExt | ConvertTo-Json -Depth 10 -Compress | Set-Content $devPath -Encoding UTF8
+```
+
+#### 例：跨 Profile 移动（如 Base → Dev）
+
+```powershell
+$basePath = "$env:APPDATA\Code\User\profiles\10a9f58d\extensions.json"
+$devPath = "$env:APPDATA\Code\User\profiles\-367578e4\extensions.json"
+
+$baseExt = Get-Content $basePath -Raw | ConvertFrom-Json
+$devExt = Get-Content $devPath -Raw | ConvertFrom-Json
+
+$targetIds = @("publisher.ext-a", "publisher.ext-b")
+
+# 从 Base 取出，追加到 Dev
+$moving = $baseExt | Where-Object { $_.identifier.id -in $targetIds }
+$newBase = $baseExt | Where-Object { $_.identifier.id -notin $targetIds }
+$newDev = $moving + $devExt   # 插入到 Dev 列表开头
+
+$newBase | ConvertTo-Json -Depth 10 -Compress | Set-Content $basePath -Encoding UTF8
+$newDev | ConvertTo-Json -Depth 10 -Compress | Set-Content $devPath -Encoding UTF8
+```
+
+### 7.4 注意事项
+
+- ⚠️ **一定要两处都改**（文档 + Profile 文件），否则文档与实际不同步
+- 🔄 如果扩展现已在 Base->Dev 中（通过继承可见），**不需要**在 Dev 的 `extensions.json` 中重复添加——除非你想让 Dev 在断开继承时仍保留该扩展
+- 📦 扩展本身是全局安装的（`%USERPROFILE%\.vscode\extensions\`），Profile 的 `extensions.json` 只是"引用清单"，增删引用**不会**影响扩展文件本身
+- 🔁 VS Code 会缓存 Profile 信息，改动 `extensions.json` 后建议重启 VS Code 或切换 Profile 使其生效


### PR DESCRIPTION
Fixes #6

In VS Code 1.127+, the `storage.json` no longer contains a `profileMenu` structure with `checked` items. This causes `getCurrentProfileName()` to fall through to the workspace-based check, which only works when a workspace/folder is open.

This PR adds a fallback that checks `profileAssociations.emptyWindows` using the current window's backup folder ID from `windowsState.lastActiveWindow.backupPath`, allowing the extension to correctly detect the active profile in empty windows.