### PR TITLE
fix: stop flattening from splitting object-valued settings like files.exclude

### DIFF
--- a/src/profileSettings.ts
+++ b/src/profileSettings.ts
@@ -12,8 +12,49 @@ export const WARNING_EXPLAIN =
   "//          The markers are used to identify inserted inherited settings.";
 
 /**
+ * Well-known VS Code settings whose value is a JSON object that must be
+ * treated as a single, opaque leaf value rather than a nested settings
+ * namespace.
+ *
+ * The keys inside these objects are user/data defined (glob patterns,
+ * language identifiers, color identifiers, environment variable names, etc.)
+ * rather than nested setting names. Flattening into them would rewrite keys
+ * such as `"README.md"` inside `files.exclude` into `files.exclude.README.md`,
+ * which VS Code does not recognise as part of the original setting.
+ *
+ * @see https://github.com/alexjthomson/inherit-profile/issues/5
+ */
+export const NON_FLATTENABLE_SETTINGS: ReadonlySet<string> = new Set([
+  "files.exclude",
+  "files.watcherExclude",
+  "files.readonlyInclude",
+  "files.readonlyExclude",
+  "files.associations",
+  "search.exclude",
+  "workbench.editorAssociations",
+  "workbench.colorCustomizations",
+  "editor.tokenColorCustomizations",
+  "editor.semanticTokenColorCustomizations",
+  "emmet.includeLanguages",
+  "emmet.syntaxProfiles",
+  "emmet.variables",
+  "explorer.fileNesting.patterns",
+  "terminal.integrated.env.linux",
+  "terminal.integrated.env.osx",
+  "terminal.integrated.env.windows",
+  "terminal.integrated.profiles.linux",
+  "terminal.integrated.profiles.osx",
+  "terminal.integrated.profiles.windows",
+  "workbench.editor.customLabels.patterns",
+]);
+
+/**
  * Recursively flattens settings into a single record that maps the setting key
  * to its value.
+ *
+ * Keys that match a known {@link NON_FLATTENABLE_SETTINGS} entry are kept as a
+ * single leaf entry, even though their value is an object, since those
+ * objects hold data (e.g. glob patterns) rather than nested settings.
  * @param settings Settings to flatten.
  * @param parentKey Parent key from previous iteration.
  * @param result Flattened result to return.
@@ -26,7 +67,12 @@ export function flattenSettings(
 ): Record<string, any> {
   for (const [key, value] of Object.entries(settings)) {
     const newKey = parentKey ? `${parentKey}.${key}` : key;
-    if (value && typeof value === "object" && !Array.isArray(value)) {
+    const isFlattenableObject =
+      value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      !NON_FLATTENABLE_SETTINGS.has(newKey);
+    if (isFlattenableObject) {
       flattenSettings(value, newKey, result);
     } else {
       result[newKey] = value;

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -340,6 +340,62 @@ suite("Extension integration", () => {
     );
     await assert.rejects(fs.access(customSettingsPath));
   });
+
+  test("inherits object-valued settings such as files.exclude without splitting their keys (issue #5)", async () => {
+    const currentProfile: ProfileDescriptor = {
+      name: "Custom",
+      location: "custom-profile",
+    };
+
+    await writeStorage(sandboxRoot, currentProfile);
+    await writeProfileSettings(
+      sandboxRoot,
+      undefined,
+      `{
+    "files.exclude": {
+        "README.md": true
+    },
+    "workbench.colorCustomizations": {
+        "editor.background": "#000000"
+    }
+}
+`,
+    );
+    await writeProfileSettings(
+      sandboxRoot,
+      currentProfile,
+      `{
+    "editor.tabSize": 2
+}
+`,
+    );
+
+    await updateConfig("parents", ["Default"]);
+    await updateCurrentProfileInheritance(createContext(sandboxRoot));
+
+    const updatedSettingsPath = path.join(
+      getProfileDirectory(sandboxRoot, currentProfile),
+      "settings.json",
+    );
+    const updatedSettingsRaw = await fs.readFile(updatedSettingsPath, "utf8");
+    const updatedSettings = parse(updatedSettingsRaw) as Record<string, any>;
+
+    // The inherited `files.exclude` setting must remain a single object-valued
+    // key, matching the shape VS Code expects, rather than being split into
+    // `files.exclude.README.md`.
+    assert.deepStrictEqual(updatedSettings["files.exclude"], {
+      "README.md": true,
+    });
+    assert.strictEqual(updatedSettings["files.exclude.README.md"], undefined);
+
+    assert.deepStrictEqual(updatedSettings["workbench.colorCustomizations"], {
+      "editor.background": "#000000",
+    });
+    assert.strictEqual(
+      updatedSettings["workbench.colorCustomizations.editor.background"],
+      undefined,
+    );
+  });
 });
 
 function createContext(rootDir: string): vscode.ExtensionContext {

--- a/src/test/unit/profileSettings.test.ts
+++ b/src/test/unit/profileSettings.test.ts
@@ -9,6 +9,7 @@ import {
   INHERITED_SETTINGS_START_MARKER,
   insertBeforeClose,
   mergeFlattenedSettings,
+  NON_FLATTENABLE_SETTINGS,
   removeTrailingComma,
   sortSettings,
   splitRawSettingsByClosingBrace,
@@ -29,6 +30,95 @@ suite("profileSettings helpers", () => {
       {
         "editor.fontSize": 14,
         "editor.rulers": [80, 100],
+        "files.autoSave": "off",
+      },
+    );
+  });
+
+  test("flattenSettings does not split keys inside files.exclude (issue #5)", () => {
+    assert.deepStrictEqual(
+      flattenSettings({
+        "files.exclude": {
+          "README.md": true,
+        },
+      }),
+      {
+        "files.exclude": {
+          "README.md": true,
+        },
+      },
+    );
+  });
+
+  test("flattenSettings does not split keys inside files.exclude when given nested notation", () => {
+    assert.deepStrictEqual(
+      flattenSettings({
+        files: {
+          exclude: {
+            "README.md": true,
+          },
+          autoSave: "off",
+        },
+      }),
+      {
+        "files.exclude": {
+          "README.md": true,
+        },
+        "files.autoSave": "off",
+      },
+    );
+  });
+
+  test("flattenSettings preserves every known non-flattenable setting as a single leaf entry", () => {
+    for (const key of NON_FLATTENABLE_SETTINGS) {
+      const value = { "some.dotted.data.key": true };
+      assert.deepStrictEqual(
+        flattenSettings({ [key]: value }),
+        { [key]: value },
+        `Expected "${key}" to be preserved as a single leaf entry.`,
+      );
+    }
+  });
+
+  test("flattenSettings keeps theme-scoped color customizations intact", () => {
+    assert.deepStrictEqual(
+      flattenSettings({
+        "workbench.colorCustomizations": {
+          "editor.background": "#000000",
+          "[Default Dark+]": {
+            "statusBar.background": "#111111",
+          },
+        },
+      }),
+      {
+        "workbench.colorCustomizations": {
+          "editor.background": "#000000",
+          "[Default Dark+]": {
+            "statusBar.background": "#111111",
+          },
+        },
+      },
+    );
+  });
+
+  test("flattenSettings still flattens ordinary nested settings that are not opaque data maps", () => {
+    assert.deepStrictEqual(
+      flattenSettings({
+        editor: {
+          fontSize: 14,
+          rulers: [80, 100],
+        },
+        terminal: {
+          integrated: {
+            fontSize: 12,
+          },
+        },
+        "files.autoSave": "off",
+      }),
+      {
+        "editor.fontSize": 14,
+        "editor.rulers": [80, 100],
+        "terminal.integrated.fontSize": 12,
         "files.autoSave": "off",
       },
     );


### PR DESCRIPTION
Fixes #5

## Problem
`flattenSettings()` recursively flattens **every** nested plain object it encounters, with no awareness that certain built-in VS Code settings hold opaque data maps (glob patterns, color identifiers, language ids, etc.) rather than nested setting namespaces.

For example, given a default profile with:
```json
"files.exclude": {
  "README.md": true
}
```
the extension would flatten this into:
```json
"files.exclude.README.md": true
```
which VS Code does **not** recognise as part of `files.exclude`, so the setting silently stops working once inherited into a custom profile (as reported in #5).

The same bug affects any other object-valued setting, e.g. `workbench.colorCustomizations`, `search.exclude`, `files.associations`, `emmet.includeLanguages`, terminal profile/env maps, etc.

## Fix
Added a `NON_FLATTENABLE_SETTINGS` set of well-known VS Code settings whose object value must be treated as a single, opaque leaf entry. `flattenSettings()` now stops recursing as soon as the accumulated key matches one of these, regardless of whether the setting was declared using dotted notation (`"files.exclude": {...}`) or nested notation (`"files": {"exclude": {...}}`).

## Tests
- **Unit tests** (`src/test/unit/profileSettings.test.ts`):
  - Reproduces the exact issue #5 scenario (`files.exclude` with a `README.md` key) and asserts it is preserved.
  - Verifies the nested-notation form (`{"files": {"exclude": {...}}}`) also flattens correctly.
  - Verifies every entry in `NON_FLATTENABLE_SETTINGS` is preserved as a single leaf.
  - Verifies theme-scoped `workbench.colorCustomizations` values stay intact.
  - Regression test confirming ordinary nested settings (e.g. `editor.fontSize`, `terminal.integrated.fontSize`) still flatten as before.
- **Integration test** (`src/test/integration/extension.test.ts`): reproduces the full inheritance pipeline end-to-end — a `Default` profile with `files.exclude` and `workbench.colorCustomizations`, inherited into a `Custom` profile — and asserts the resulting `settings.json` keeps them intact instead of splitting into `files.exclude.README.md` / `workbench.colorCustomizations.editor.background`.

All existing tests continue to pass:
- `npm run unit-test` → 29 passing
- `npm test` (vscode-test integration suite) → 5 passing
- `npm run lint` → clean
